### PR TITLE
Generate our own uri for dataset and resource on XML export

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ To install ckanext-dcatapchharvest:
 
      pip install ckanext-dcatapchharvest
 
-3. Add ``dcat_ch_rdf_harvester and ogdch_dcat`` to the ``ckan.plugins`` setting in your CKAN
+3. Add `dcat_ch_rdf_harvester ogdch_dcat` to the `ckan.plugins` setting in your CKAN
    config file (by default the config file is located at
-   ``/etc/ckan/default/production.ini``).
+   `/etc/ckan/default/production.ini`).
 
 4. Restart CKAN. For example if you've deployed CKAN with Apache on Ubuntu:
 
@@ -40,23 +40,29 @@ do:
     pip install -r dev-requirements.txt
     pip install -r requirements.txt
 
-## Configuration options for the Swiss DCAT Harevster
+## Configuration options for the Swiss DCAT Harvester
 
-The Swiss DCAT Harvester inherits all configuration options from the DCAT rdf harvester. 
-Additionally the following additional configuration options:
+When importing data that contains URIs from a test environment, the harvester can be configured
+to overwrite those URIs with ones containing the current `ckan.site_url`. Add any test urls to
+the CKAN config file, comma separated:
 
-Exclude datasets from import: this will prevent the import of datasets with ceratin identifiers.
+    ckanext.dcat_ch_rdf_harvester.test_env_urls = https://test.example.com,https://staging.example.com 
+
+The Swiss DCAT Harvester inherits all configuration options from the DCAT RDF harvester. 
+It has the following additional configuration options:
+
+Exclude datasets from import: this will prevent the import of datasets with certain identifiers.
 
 ```
 {"excluded_dataset_identifiers":["aaa@oevch", "fahrtprognose@oevch"]}
 ```
 
-Exclude resource rights from import: this prevent the import of datasets with certain resource 
+Exclude resource rights from import: this prevents the import of datasets with certain resource 
 rights.
 
 ```
 {"excluded_rights":["NonCommercialWithPermission-CommercialWithPermission-ReferenceRequired"]}
 ```
 
-Both configurations only works on the first import. Once imported the harvest 
+Both configurations only work on the first import. Once imported the harvest 
 source must be cleared in order to prevent the import.

--- a/ckanext/dcatapchharvest/dcat_helpers.py
+++ b/ckanext/dcatapchharvest/dcat_helpers.py
@@ -1,5 +1,6 @@
 import iribaker
 from urlparse import urlparse
+from ckantoolkit import config
 
 
 def uri_to_iri(uri):
@@ -22,3 +23,68 @@ def uri_to_iri(uri):
 def get_langs():
     language_priorities = ['en', 'de', 'fr', 'it']
     return language_priorities
+
+
+def dataset_uri(dataset_dict):
+    """
+    Returns a URI for the dataset
+
+    This is a hack/workaround for the use case where data publishers create
+    datsets on the test environment, export them to XML and then import them
+    to the production site. In that case, the dataset uris will contain the
+    url of the test environment, so we have to replace it with the prod one.
+    """
+    test_env_urls = config.get(
+        'ckanext.dcat_ch_rdf_harvester.test_env_urls').split(',')
+
+    uri = dataset_dict.get('uri', '')
+    if not uri:
+        for extra in dataset_dict.get('extras', []):
+            if extra['key'] == 'uri' and extra['value'] != 'None':
+                uri = extra['value']
+                break
+    for test_url in test_env_urls:
+        if test_url in uri:
+            uri = ''
+            break
+    if not uri:
+        site_url = config.get('ckan.site_url')
+        uri = '{0}/perma/{1}'.format(site_url,
+                                     dataset_dict.get('identifier'))
+
+    return uri
+
+
+def resource_uri(resource_dict):
+    """
+    Returns a URI for the resource
+
+    This is a hack/workaround for the use case where data publishers create
+    datsets on the test environment, export them to XML and then import them
+    to the production site. In that case, the resource uri will contain the
+    url of the test environment, so we have to replace it with the prod one.
+
+    If this function is called when importing the resource, it just removes
+    test-environment uri. We can't generate the new one yet as the dataset and
+    resource haven't been saved. This is all right as it will be generated
+    when the dataset is output in RDF format.
+    """
+
+    uri = resource_dict.get('uri', '')
+    if uri:
+        test_env_urls = config.get(
+            'ckanext.dcat_ch_rdf_harvester.test_env_urls').split(',')
+        for test_url in test_env_urls:
+            if test_url in uri:
+                uri = ''
+                break
+    if not uri or uri == 'None':
+        site_url = config.get('ckan.site_url')
+        dataset_id = resource_dict.get('package_id')
+        resource_id = resource_dict.get('id')
+        if dataset_id and resource_id:
+            uri = '{0}/dataset/{1}/resource/{2}'.format(site_url.rstrip('/'),
+                                                        dataset_id,
+                                                        resource_dict['id'])
+
+    return uri

--- a/ckanext/dcatapchharvest/profiles.py
+++ b/ckanext/dcatapchharvest/profiles.py
@@ -9,7 +9,7 @@ from ckantoolkit import config
 import re
 
 from ckanext.dcat.profiles import RDFProfile, SchemaOrgProfile
-from ckanext.dcat.utils import resource_uri, publisher_uri_from_dataset_dict
+from ckanext.dcat.utils import publisher_uri_from_dataset_dict
 from ckan.lib.munge import munge_tag
 
 import ckanext.dcatapchharvest.dcat_helpers as dh
@@ -311,10 +311,8 @@ class SwissDCATAPProfile(MultiLangProfile):
         for see_also in see_alsos:
             dataset_dict['see_alsos'].append({'dataset_identifier': see_also})
 
-        # Dataset URI (explicitly show the missing ones)
-        dataset_uri = (unicode(dataset_ref)
-                       if isinstance(dataset_ref, rdflib.term.URIRef)
-                       else '')
+        # Dataset URI
+        dataset_uri = dh.dataset_uri(dataset_dict)
         dataset_dict['extras'].append({'key': 'uri', 'value': dataset_uri})
 
         # Resources
@@ -385,10 +383,7 @@ class SwissDCATAPProfile(MultiLangProfile):
                 resource_dict['byte_size'] = byte_size
 
             # Distribution URI (explicitly show the missing ones)
-            resource_dict['uri'] = (unicode(distribution)
-                                    if isinstance(distribution,
-                                                  rdflib.term.URIRef)
-                                    else '')
+            resource_dict['uri'] = dh.resource_uri(resource_dict)
 
             dataset_dict['resources'].append(resource_dict)
 
@@ -399,6 +394,9 @@ class SwissDCATAPProfile(MultiLangProfile):
     def graph_from_dataset(self, dataset_dict, dataset_ref):  # noqa
 
         log.debug("Create graph from dataset '%s'" % dataset_dict['name'])
+
+        dataset_uri = dh.dataset_uri(dataset_dict)
+        dataset_ref = URIRef(dataset_uri)
 
         g = self.g
 
@@ -569,8 +567,7 @@ class SwissDCATAPProfile(MultiLangProfile):
 
         # Resources
         for resource_dict in dataset_dict.get('resources', []):
-
-            distribution = URIRef(resource_uri(resource_dict))
+            distribution = URIRef(dh.resource_uri(resource_dict))
 
             g.add((dataset_ref, DCAT.distribution, distribution))
             g.add((distribution, RDF.type, DCAT.Distribution))


### PR DESCRIPTION
If a dataset or resource doesn't have a uri, RDFSerializer will use its url instead when serializing to XML. We don't want these uris to be tied to opendata.swiss, as opendata.swiss is only a metadata catalog, so we use this method instead.