### PR TITLE
correct package dates on dcat export:

### DIFF
--- a/ckanext/dcatapchharvest/profiles.py
+++ b/ckanext/dcatapchharvest/profiles.py
@@ -442,8 +442,8 @@ class SwissDCATAPProfile(MultiLangProfile):
 
         # Dates
         items = [
-            ('issued', DCT.issued, ['metadata_created'], Literal),
-            ('modified', DCT.modified, ['metadata_modified'], Literal),
+            ('issued', DCT.issued, ['issued'], Literal),
+            ('modified', DCT.modified, ['modified'], Literal),
         ]
         self._add_date_triples_from_dict(dataset_dict, dataset_ref, items)
 


### PR DESCRIPTION
issued and modified should be exported not metadata_created and metadata_updated