### PR TITLE
adapt to change in ckanext-dcat

### DIFF
--- a/ckanext/dcatapchharvest/profiles.py
+++ b/ckanext/dcatapchharvest/profiles.py
@@ -696,7 +696,6 @@ class SwissSchemaOrgProfile(SchemaOrgProfile, MultiLangProfile):
                 publisher_details = CleanedURIRef(publisher_uri_fallback)
             else:
                 # No organization nor publisher_uri
-                # No publisher_uri
                 publisher_details = BNode()
 
             self.g.add((publisher_details, RDF.type, SCHEMA.Organization))


### PR DESCRIPTION
the to get the publisher uri for building the schema.org representation
of a dataset changed name and function. Since we were using this function
the usage needed to be adapted to that change.