### PR TITLE
Change to the EU frequency uris

### DIFF
--- a/ckanext/dcatapchharvest/dcat_helpers.py
+++ b/ckanext/dcatapchharvest/dcat_helpers.py
@@ -130,8 +130,9 @@ def get_frequency_values():
     file = os.path.join(__location__, 'frequency.ttl')
     g.parse(file, format='turtle')
     for ogdch_frequency_ref in g.subjects(predicate=RDF.type,
-                                      object=SKOS.Concept):
-        for obj in g.objects(subject=ogdch_frequency_ref, predicate=SKOS.exactMatch):
+                                          object=SKOS.Concept):
+        for obj in g.objects(subject=ogdch_frequency_ref,
+                             predicate=SKOS.exactMatch):
             frequency_mapping[ogdch_frequency_ref] = obj
     return frequency_mapping
 

--- a/ckanext/dcatapchharvest/dcat_helpers.py
+++ b/ckanext/dcatapchharvest/dcat_helpers.py
@@ -124,11 +124,16 @@ def resource_uri(resource_dict, distribution=None):
 
 def get_frequency_values():
     g = Graph()
+    frequency_mapping = {}
     for prefix, namespace in frequency_namespaces.items():
         g.bind(prefix, namespace)
     file = os.path.join(__location__, 'frequency.ttl')
     g.parse(file, format='turtle')
-    return [item for item in g.subjects(object=SKOS.Concept)]
+    for ogdch_frequency_ref in g.subjects(predicate=RDF.type,
+                                      object=SKOS.Concept):
+        for obj in g.objects(subject=ogdch_frequency_ref, predicate=SKOS.exactMatch):
+            frequency_mapping[ogdch_frequency_ref] = obj
+    return frequency_mapping
 
 
 def get_theme_mapping():

--- a/ckanext/dcatapchharvest/frequency.ttl
+++ b/ckanext/dcatapchharvest/frequency.ttl
@@ -1,180 +1,222 @@
-# Copy of http://purl.org/dc/terms/ in case the vocabulary is not available online.
-@prefix dc: <http://purl.org/dc/terms/> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix ns0: <http://purl.org/dc/dcam/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
+@prefix ns0: <http://publications.europa.eu/ontology/authority/> .
 
-<http://purl.org/cld/freq/>
-  dc:title "The Collection Description Frequency Namespace"@en ;
-  dc:creator [ rdfs:label "Dublin Core Collection Description Task Group" ] ;
-  dc:modified "2013-05-10"^^dc:W3CDTF .
+<http://publications.europa.eu/resource/authority/frequency/OTHER>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The event occurs with another type of regularity (for instance, every leap year)."@en ;
+  skos:prefLabel "other"@en .
 
-<http://purl.org/cld/freq/triennial>
-  a skos:Concept ;
-  rdfs:label "Triennial"@en ;
-  skos:prefLabel "Triennial"@en ;
-  rdfs:comment "The event occurs every three years."@en ;
-  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
-  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
-  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
-  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+<http://publications.europa.eu/resource/authority/frequency/WEEKLY>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The event occurs once a week."@en ;
+  skos:prefLabel "weekly"@en ;
+  skos:exactMatch <http://purl.org/cld/freq/weekly> .
 
-<http://purl.org/cld/freq/biennial>
-  a skos:Concept ;
-  rdfs:label "Biennial"@en ;
-  skos:prefLabel "Biennial"@en ;
-  rdfs:comment "The event occurs every two years."@en ;
-  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
-  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
-  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
-  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+<http://publications.europa.eu/resource/authority/frequency>
+  a skos:ConceptScheme, owl:Ontology ;
+  rdfs:label "Frequency"@en ;
+  owl:imports <http://publications.europa.eu/ontology/euvoc> ;
+  rdfs:comment "Frequency"^^rdfs:Literal ;
+  owl:versionInfo "20190619-0" ;
+  skos:prefLabel "Frequency"@en ;
+  dc:identifier "http://publications.europa.eu/resource/authority/frequency" ;
+  skosxl:prefLabel [ ] ;
+  ns0:prefLabel "Frequency"@en ;
+  ns0:table.id "frequency" ;
+  ns0:table.version.number "20190619-0" ;
+  owl:versionIRI <http://publications.europa.eu/resource/authority/frequency/20190619-0> .
 
-<http://purl.org/cld/freq/annual>
-  a skos:Concept ;
-  rdfs:label "Annual"@en ;
-  skos:prefLabel "Annual"@en ;
-  rdfs:comment "The event occurs once a year."@en ;
-  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
-  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
-  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
-  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+<http://publications.europa.eu/resource/authority/frequency/ANNUAL>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The event occurs once a year."@en ;
+  skos:prefLabel "annual"@en ;
+  skos:exactMatch <http://purl.org/cld/freq/annual> .
 
-<http://purl.org/cld/freq/semiannual>
-  a skos:Concept ;
-  rdfs:label "Semiannual"@en ;
-  skos:prefLabel "Semiannual"@en ;
-  rdfs:comment "The event occurs twice a year."@en ;
-  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
-  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
-  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
-  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+<http://publications.europa.eu/resource/authority/frequency/ANNUAL_2>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The event occurs twice a year."@en ;
+  skos:prefLabel "semiannual"@en ;
+  skos:exactMatch <http://purl.org/cld/freq/semiannual> .
 
-<http://purl.org/cld/freq/threeTimesAYear>
-  a skos:Concept ;
-  rdfs:label "Three times a year"@en ;
-  skos:prefLabel "Three times a year"@en ;
-  rdfs:comment "The event occurs three times a year."@en ;
-  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
-  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
-  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
-  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+<http://publications.europa.eu/resource/authority/frequency/ANNUAL_3>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The event occurs three times a year."@en ;
+  skos:prefLabel "three times a year"@en ;
+  skos:exactMatch <http://purl.org/cld/freq/threeTimesAYear> .
 
-<http://purl.org/cld/freq/quarterly>
-  a skos:Concept ;
-  rdfs:label "Quarterly"@en ;
-  skos:prefLabel "Quarterly"@en ;
-  rdfs:comment "The event occurs every three months."@en ;
-  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
-  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
-  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
-  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+<http://publications.europa.eu/resource/authority/frequency/BIENNIAL>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The event occurs every two years."@en ;
+  skos:prefLabel "biennial"@en ;
+  skos:exactMatch <http://purl.org/cld/freq/biennial> .
 
-<http://purl.org/cld/freq/bimonthly>
-  a skos:Concept ;
-  rdfs:label "Bimonthly"@en ;
-  skos:prefLabel "Bimonthly"@en ;
-  rdfs:comment "The event occurs every two months."@en ;
-  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
-  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
-  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
-  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+<http://publications.europa.eu/resource/authority/frequency/BIMONTHLY>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The event occurs every two months."@en ;
+  skos:prefLabel "bimonthly"@en ;
+  skos:exactMatch <http://purl.org/cld/freq/bimonthly> .
 
-<http://purl.org/cld/freq/monthly>
-  a skos:Concept ;
-  rdfs:label "Monthly"@en ;
-  skos:prefLabel "Monthly"@en ;
-  rdfs:comment "The event occurs once a month."@en ;
-  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
-  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
-  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
-  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+<http://publications.europa.eu/resource/authority/frequency/BIWEEKLY>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The event occurs every two weeks."@en ;
+  skos:prefLabel "biweekly"@en ;
+  skos:exactMatch <http://purl.org/cld/freq/biweekly> .
 
-<http://purl.org/cld/freq/semimonthly>
-  a skos:Concept ;
-  rdfs:label "Semimonthly"@en ;
-  skos:prefLabel "Semimonthly"@en ;
-  rdfs:comment "The event occurs twice a month."@en ;
-  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
-  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
-  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
-  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+<http://publications.europa.eu/resource/authority/frequency/CONT>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The item is updated more frequent than daily."@en ;
+  skos:prefLabel "continuous"@en ;
+  skos:exactMatch <http://purl.org/cld/freq/continuous> .
 
-<http://purl.org/cld/freq/biweekly>
-  a skos:Concept ;
-  rdfs:label "Biweekly"@en ;
-  skos:prefLabel "Biweekly"@en ;
-  rdfs:comment "The event occurs every two weeks."@en ;
-  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
-  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
-  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
-  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+<http://publications.europa.eu/resource/authority/frequency/DAILY>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The event occurs once a day."@en ;
+  skos:prefLabel "daily"@en ;
+  skos:exactMatch <http://purl.org/cld/freq/daily> .
 
-<http://purl.org/cld/freq/threeTimesAMonth>
-  a skos:Concept ;
-  rdfs:label "Three times a month"@en ;
-  skos:prefLabel "Three times a month"@en ;
-  rdfs:comment "The event occurs three times a month."@en ;
-  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
-  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
-  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
-  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+<http://publications.europa.eu/resource/authority/frequency/DAILY_2>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The event occurs twice a day."@en ;
+  skos:prefLabel "twice a day"@en .
 
-<http://purl.org/cld/freq/weekly>
-  a skos:Concept ;
-  rdfs:label "Weekly"@en ;
-  skos:prefLabel "Weekly"@en ;
-  rdfs:comment "The event occurs once a week."@en ;
-  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
-  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
-  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
-  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+<http://publications.europa.eu/resource/authority/frequency/IRREG>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The event occurs at uneven intervals."@en ;
+  skos:prefLabel "irregular"@en ;
+  skos:exactMatch <http://purl.org/cld/freq/irregular> .
 
-<http://purl.org/cld/freq/semiweekly>
-  a skos:Concept ;
-  rdfs:label "Semiweekly"@en ;
-  skos:prefLabel "Semiweekly"@en ;
-  rdfs:comment "The event occurs twice a week."@en ;
-  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
-  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
-  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
-  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+<http://publications.europa.eu/resource/authority/frequency/MONTHLY>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The event occurs once a month."@en ;
+  skos:prefLabel "monthly"@en ;
+  skos:exactMatch <http://purl.org/cld/freq/monthly> .
 
-<http://purl.org/cld/freq/threeTimesAWeek>
-  a skos:Concept ;
-  rdfs:label "Three times a week"@en ;
-  skos:prefLabel "Three times a week"@en ;
-  rdfs:comment "The event occurs three times a week."@en ;
-  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
-  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
-  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
-  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+<http://publications.europa.eu/resource/authority/frequency/MONTHLY_2>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The event occurs twice a month."@en ;
+  skos:prefLabel "semimonthly"@en ;
+  skos:exactMatch <http://purl.org/cld/freq/semimonthly> .
 
-<http://purl.org/cld/freq/daily>
-  a skos:Concept ;
-  rdfs:label "Daily"@en ;
-  skos:prefLabel "Daily"@en ;
-  rdfs:comment "The event occurs once a day."@en ;
-  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
-  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
-  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
-  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+<http://publications.europa.eu/resource/authority/frequency/MONTHLY_3>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The event occurs three times a month."@en ;
+  skos:prefLabel "three times a month"@en ;
+  skos:exactMatch <http://purl.org/cld/freq/threeTimesAMonth> .
 
-<http://purl.org/cld/freq/continuous>
-  a skos:Concept ;
-  rdfs:label "Continuous"@en ;
-  skos:prefLabel "Continuous"@en ;
-  rdfs:comment "The event repeats without interruption."@en ;
-  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
-  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
-  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
-  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+<http://publications.europa.eu/resource/authority/frequency/NEVER>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The item is never updated."@en ;
+  skos:prefLabel "never"@en .
 
-<http://purl.org/cld/freq/irregular>
-  a skos:Concept ;
-  rdfs:label "Irregular"@en ;
-  skos:prefLabel "Irregular"@en ;
-  rdfs:comment "The event occurs at uneven intervals."@en ;
-  rdfs:isDefinedBy <http://purl.org/cld/freq/> ;
-  rdfs:seeAlso <http://www.loc.gov/marc/holdings/echdcapt.html> ;
-  skos:inScheme <http://purl.org/cld/terms/Frequency> ;
-  ns0:memberOf <http://purl.org/cld/terms/Frequency> .
+<http://publications.europa.eu/resource/authority/frequency/OP_DATPRO>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:prefLabel "Provisional data"@en .
+
+<http://publications.europa.eu/resource/authority/frequency/QUARTERLY>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The event occurs every three months."@en ;
+  skos:prefLabel "quarterly"@en ;
+  skos:exactMatch <http://purl.org/cld/freq/quarterly> .
+
+<http://publications.europa.eu/resource/authority/frequency/TRIENNIAL>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The event occurs every three years."@en ;
+  skos:prefLabel "triennial"@en ;
+  skos:exactMatch <http://purl.org/cld/freq/triennial> .
+
+<http://publications.europa.eu/resource/authority/frequency/UNKNOWN>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The event occurs with unknown regularity."@en ;
+  skos:prefLabel "unknown"@en .
+
+<http://publications.europa.eu/resource/authority/frequency/UPDATE_CONT>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The event repeats without interruption."@en ;
+  skos:prefLabel "continuously updated"@en .
+
+<http://publications.europa.eu/resource/authority/frequency/WEEKLY_2>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The event occurs twice a week."@en ;
+  skos:prefLabel "semiweekly"@en ;
+  skos:exactMatch <http://purl.org/cld/freq/semiweekly> .
+
+<http://publications.europa.eu/resource/authority/frequency/WEEKLY_3>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The event occurs three times a week."@en ;
+  skos:prefLabel "three times a week"@en ;
+  skos:exactMatch <http://purl.org/cld/freq/threeTimesAWeek> .
+
+<http://publications.europa.eu/resource/authority/frequency/QUINQUENNIAL>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The event occurs every five years."@en ;
+  skos:prefLabel "quinquennial"@en .
+
+<http://publications.europa.eu/resource/authority/frequency/DECENNIAL>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The event occurs every ten years."@en ;
+  skos:prefLabel "decennial"@en .
+
+<http://publications.europa.eu/resource/authority/frequency/HOURLY>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The event occurs every hour."@en ;
+  skos:prefLabel "hourly"@en .
+
+<http://publications.europa.eu/resource/authority/frequency/QUADRENNIAL>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The event occurs every four years."@en ;
+  skos:prefLabel "quadrennial"@en .
+
+<http://publications.europa.eu/resource/authority/frequency/BIHOURLY>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The event occurs every two hours."@en ;
+  skos:prefLabel "bihourly"@en .
+
+<http://publications.europa.eu/resource/authority/frequency/TRIHOURLY>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The event occurs every three hours."@en ;
+  skos:prefLabel "trihourly"@en .
+
+<http://publications.europa.eu/resource/authority/frequency/BIDECENNIAL>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The event occurs every twenty years."@en ;
+  skos:prefLabel "bidecennial"@en .
+
+<http://publications.europa.eu/resource/authority/frequency/TRIDECENNIAL>
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The event occurs every thirty years."@en ;
+  skos:prefLabel "tridecennial"@en .

--- a/ckanext/dcatapchharvest/frequency.ttl
+++ b/ckanext/dcatapchharvest/frequency.ttl
@@ -6,12 +6,14 @@
 @prefix ns0: <http://publications.europa.eu/ontology/authority/> .
 
 <http://publications.europa.eu/resource/authority/frequency/OTHER>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The event occurs with another type of regularity (for instance, every leap year)."@en ;
   skos:prefLabel "other"@en .
 
 <http://publications.europa.eu/resource/authority/frequency/WEEKLY>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The event occurs once a week."@en ;
@@ -33,6 +35,7 @@
   owl:versionIRI <http://publications.europa.eu/resource/authority/frequency/20190619-0> .
 
 <http://publications.europa.eu/resource/authority/frequency/ANNUAL>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The event occurs once a year."@en ;
@@ -40,6 +43,7 @@
   skos:exactMatch <http://purl.org/cld/freq/annual> .
 
 <http://publications.europa.eu/resource/authority/frequency/ANNUAL_2>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The event occurs twice a year."@en ;
@@ -47,6 +51,7 @@
   skos:exactMatch <http://purl.org/cld/freq/semiannual> .
 
 <http://publications.europa.eu/resource/authority/frequency/ANNUAL_3>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The event occurs three times a year."@en ;
@@ -54,6 +59,7 @@
   skos:exactMatch <http://purl.org/cld/freq/threeTimesAYear> .
 
 <http://publications.europa.eu/resource/authority/frequency/BIENNIAL>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The event occurs every two years."@en ;
@@ -61,6 +67,7 @@
   skos:exactMatch <http://purl.org/cld/freq/biennial> .
 
 <http://publications.europa.eu/resource/authority/frequency/BIMONTHLY>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The event occurs every two months."@en ;
@@ -68,6 +75,7 @@
   skos:exactMatch <http://purl.org/cld/freq/bimonthly> .
 
 <http://publications.europa.eu/resource/authority/frequency/BIWEEKLY>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The event occurs every two weeks."@en ;
@@ -75,6 +83,7 @@
   skos:exactMatch <http://purl.org/cld/freq/biweekly> .
 
 <http://publications.europa.eu/resource/authority/frequency/CONT>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The item is updated more frequent than daily."@en ;
@@ -82,6 +91,7 @@
   skos:exactMatch <http://purl.org/cld/freq/continuous> .
 
 <http://publications.europa.eu/resource/authority/frequency/DAILY>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The event occurs once a day."@en ;
@@ -89,12 +99,14 @@
   skos:exactMatch <http://purl.org/cld/freq/daily> .
 
 <http://publications.europa.eu/resource/authority/frequency/DAILY_2>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The event occurs twice a day."@en ;
   skos:prefLabel "twice a day"@en .
 
 <http://publications.europa.eu/resource/authority/frequency/IRREG>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The event occurs at uneven intervals."@en ;
@@ -102,6 +114,7 @@
   skos:exactMatch <http://purl.org/cld/freq/irregular> .
 
 <http://publications.europa.eu/resource/authority/frequency/MONTHLY>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The event occurs once a month."@en ;
@@ -109,6 +122,7 @@
   skos:exactMatch <http://purl.org/cld/freq/monthly> .
 
 <http://publications.europa.eu/resource/authority/frequency/MONTHLY_2>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The event occurs twice a month."@en ;
@@ -116,6 +130,7 @@
   skos:exactMatch <http://purl.org/cld/freq/semimonthly> .
 
 <http://publications.europa.eu/resource/authority/frequency/MONTHLY_3>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The event occurs three times a month."@en ;
@@ -123,17 +138,20 @@
   skos:exactMatch <http://purl.org/cld/freq/threeTimesAMonth> .
 
 <http://publications.europa.eu/resource/authority/frequency/NEVER>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The item is never updated."@en ;
   skos:prefLabel "never"@en .
 
 <http://publications.europa.eu/resource/authority/frequency/OP_DATPRO>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:prefLabel "Provisional data"@en .
 
 <http://publications.europa.eu/resource/authority/frequency/QUARTERLY>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The event occurs every three months."@en ;
@@ -141,6 +159,7 @@
   skos:exactMatch <http://purl.org/cld/freq/quarterly> .
 
 <http://publications.europa.eu/resource/authority/frequency/TRIENNIAL>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The event occurs every three years."@en ;
@@ -148,18 +167,21 @@
   skos:exactMatch <http://purl.org/cld/freq/triennial> .
 
 <http://publications.europa.eu/resource/authority/frequency/UNKNOWN>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The event occurs with unknown regularity."@en ;
   skos:prefLabel "unknown"@en .
 
 <http://publications.europa.eu/resource/authority/frequency/UPDATE_CONT>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The event repeats without interruption."@en ;
   skos:prefLabel "continuously updated"@en .
 
 <http://publications.europa.eu/resource/authority/frequency/WEEKLY_2>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The event occurs twice a week."@en ;
@@ -167,6 +189,7 @@
   skos:exactMatch <http://purl.org/cld/freq/semiweekly> .
 
 <http://publications.europa.eu/resource/authority/frequency/WEEKLY_3>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The event occurs three times a week."@en ;
@@ -174,48 +197,56 @@
   skos:exactMatch <http://purl.org/cld/freq/threeTimesAWeek> .
 
 <http://publications.europa.eu/resource/authority/frequency/QUINQUENNIAL>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The event occurs every five years."@en ;
   skos:prefLabel "quinquennial"@en .
 
 <http://publications.europa.eu/resource/authority/frequency/DECENNIAL>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The event occurs every ten years."@en ;
   skos:prefLabel "decennial"@en .
 
 <http://publications.europa.eu/resource/authority/frequency/HOURLY>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The event occurs every hour."@en ;
   skos:prefLabel "hourly"@en .
 
 <http://publications.europa.eu/resource/authority/frequency/QUADRENNIAL>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The event occurs every four years."@en ;
   skos:prefLabel "quadrennial"@en .
 
 <http://publications.europa.eu/resource/authority/frequency/BIHOURLY>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The event occurs every two hours."@en ;
   skos:prefLabel "bihourly"@en .
 
 <http://publications.europa.eu/resource/authority/frequency/TRIHOURLY>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The event occurs every three hours."@en ;
   skos:prefLabel "trihourly"@en .
 
 <http://publications.europa.eu/resource/authority/frequency/BIDECENNIAL>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The event occurs every twenty years."@en ;
   skos:prefLabel "bidecennial"@en .
 
 <http://publications.europa.eu/resource/authority/frequency/TRIDECENNIAL>
+  a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
   skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
   skos:definition "The event occurs every thirty years."@en ;

--- a/ckanext/dcatapchharvest/profiles.py
+++ b/ckanext/dcatapchharvest/profiles.py
@@ -254,7 +254,6 @@ class SwissDCATAPProfile(MultiLangProfile):
         # Basic fields
         for key, predicate in (
                 ('identifier', DCT.identifier),
-                #('accrual_periodicity', DCT.accrualPeriodicity),
                 ('spatial_uri', DCT.spatial),
                 ('spatial', DCT.spatial),
                 ('url', DCAT.landingPage),

--- a/ckanext/dcatapchharvest/profiles.py
+++ b/ckanext/dcatapchharvest/profiles.py
@@ -229,6 +229,18 @@ class SwissDCATAPProfile(MultiLangProfile):
         except (ValueError, KeyError, TypeError, IndexError):
             return None
 
+    def _get_eu_ccrualPeriodicity(self, subject, predicate):
+        ogdch_value = self._object_value(subject, predicate)
+        ogdch_value = URIRef(ogdch_value)
+        for key, value in valid_frequencies.items():
+            if ogdch_value == value:
+                ogdch_value = key
+                return ogdch_value
+            elif ogdch_value == key:
+                log.info("EU frequencies are already used.")
+                return ogdch_value
+        return "There is no such frequency"
+
     def parse_dataset(self, dataset_dict, dataset_ref):  # noqa
         log.debug("Parsing dataset '%r'" % dataset_ref)
 
@@ -242,12 +254,20 @@ class SwissDCATAPProfile(MultiLangProfile):
         # Basic fields
         for key, predicate in (
                 ('identifier', DCT.identifier),
-                ('accrual_periodicity', DCT.accrualPeriodicity),
+                #('accrual_periodicity', DCT.accrualPeriodicity),
                 ('spatial_uri', DCT.spatial),
                 ('spatial', DCT.spatial),
                 ('url', DCAT.landingPage),
         ):
             value = self._object_value(dataset_ref, predicate)
+            if value:
+                dataset_dict[key] = value
+
+        # Accrual periodicity
+        for key, predicate in (
+                ('accrual_periodicity', DCT.accrualPeriodicity),
+        ):
+            value = self._get_eu_ccrualPeriodicity(dataset_ref, predicate)
             if value:
                 dataset_dict[key] = value
 

--- a/ckanext/dcatapchharvest/profiles.py
+++ b/ckanext/dcatapchharvest/profiles.py
@@ -229,7 +229,7 @@ class SwissDCATAPProfile(MultiLangProfile):
         except (ValueError, KeyError, TypeError, IndexError):
             return None
 
-    def _get_eu_ccrualPeriodicity(self, subject, predicate):
+    def _get_eu_accrual_periodicity(self, subject, predicate):
         ogdch_value = self._object_value(subject, predicate)
         ogdch_value = URIRef(ogdch_value)
         for key, value in valid_frequencies.items():

--- a/ckanext/dcatapchharvest/profiles.py
+++ b/ckanext/dcatapchharvest/profiles.py
@@ -266,7 +266,7 @@ class SwissDCATAPProfile(MultiLangProfile):
         for key, predicate in (
                 ('accrual_periodicity', DCT.accrualPeriodicity),
         ):
-            value = self._get_eu_ccrualPeriodicity(dataset_ref, predicate)
+            value = self._get_eu_accrual_periodicity(dataset_ref, predicate)
             if value:
                 dataset_dict[key] = value
 


### PR DESCRIPTION
Store EU frequency uris and values (http://publications.europa.eu/resource/authority/frequency)
instead of URLS of the DCAT vocabulary: http://purl.org/cld/freq
-  EU vocabulary mapped to the old frequency ulrs