### PR TITLE
Mapping  of the completelyIrregular frequency to EU Irregular frequency

### DIFF
--- a/ckanext/dcatapchharvest/dcat_helpers.py
+++ b/ckanext/dcatapchharvest/dcat_helpers.py
@@ -132,7 +132,6 @@ def get_frequency_values():
     for ogdch_frequency_ref in g.subjects(predicate=RDF.type,
                                           object=SKOS.Concept):
         frequency_mapping[ogdch_frequency_ref] = None
-        
         for obj in g.objects(subject=ogdch_frequency_ref,
                              predicate=SKOS.exactMatch):
             frequency_mapping[ogdch_frequency_ref] = obj

--- a/ckanext/dcatapchharvest/frequency.ttl
+++ b/ckanext/dcatapchharvest/frequency.ttl
@@ -113,6 +113,14 @@
   skos:prefLabel "irregular"@en ;
   skos:exactMatch <http://purl.org/cld/freq/irregular> .
 
+<http://publications.europa.eu/resource/authority/frequency/IRREG>
+  a skos:Concept ;
+  skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:topConceptOf <http://publications.europa.eu/resource/authority/frequency> ;
+  skos:definition "The event occurs at uneven intervals."@en ;
+  skos:prefLabel "irregular"@en ;
+  skos:exactMatch <http://purl.org/cld/freq/completelyIrregular> .
+
 <http://publications.europa.eu/resource/authority/frequency/MONTHLY>
   a skos:Concept ;
   skos:inScheme <http://publications.europa.eu/resource/authority/frequency> ;


### PR DESCRIPTION
There are some datasets with frequency  "completelyIrregular" on the TEST. This value should be changed to "Irregular"  during harvesting. Therefore, an additional mapping is required  