### PR TITLE
fix: date cleaning and mapping on import of a dataset

### DIFF
--- a/ckanext/dcatapchharvest/profiles.py
+++ b/ckanext/dcatapchharvest/profiles.py
@@ -239,7 +239,7 @@ class SwissDCATAPProfile(MultiLangProfile):
             end_date = self._object_value(temporal_node, SCHEMA.endDate)
             if not start_date or not end_date:
                 continue
-            cleaned_start_date = self._clean_datetime(end_date)
+            cleaned_start_date = self._clean_datetime(start_date)
             cleaned_end_date = self._clean_datetime(start_date)
             if not cleaned_start_date or not cleaned_end_date:
                 continue

--- a/ckanext/dcatapchharvest/profiles.py
+++ b/ckanext/dcatapchharvest/profiles.py
@@ -240,7 +240,7 @@ class SwissDCATAPProfile(MultiLangProfile):
             if not start_date or not end_date:
                 continue
             cleaned_start_date = self._clean_datetime(start_date)
-            cleaned_end_date = self._clean_datetime(start_date)
+            cleaned_end_date = self._clean_datetime(end_date)
             if not cleaned_start_date or not cleaned_end_date:
                 continue
             temporals.append({

--- a/ckanext/dcatapchharvest/profiles.py
+++ b/ckanext/dcatapchharvest/profiles.py
@@ -2,6 +2,7 @@ from rdflib import URIRef, BNode, Literal
 from rdflib.namespace import Namespace, RDFS, RDF, SKOS
 
 from datetime import datetime
+import isodate
 
 from ckantoolkit import config
 
@@ -236,27 +237,25 @@ class SwissDCATAPProfile(MultiLangProfile):
         for temporal_node in self.g.objects(subject, predicate):
             start_date = self._object_value(temporal_node, SCHEMA.startDate)
             end_date = self._object_value(temporal_node, SCHEMA.endDate)
-            if start_date or end_date:
-                temporals.append({
-                    'start_date': self._clean_datetime(start_date),
-                    'end_date': self._clean_datetime(end_date)
-                })
+            if not start_date or not end_date:
+                continue
+            cleaned_start_date = self._clean_datetime(end_date)
+            cleaned_end_date = self._clean_datetime(start_date)
+            if not cleaned_start_date or not cleaned_end_date:
+                continue
+            temporals.append({
+                'start_date': self._clean_datetime(start_date),
+                'end_date': self._clean_datetime(end_date)
+            })
 
         return temporals
 
     def _clean_datetime(self, datetime_value):
         try:
-            d = datetime.strptime(
-                datetime_value[0:len('YYYY-MM-DD')],
-                '%Y-%m-%d'
-            )
-            # we have to calculate this manually since the
-            # time library of Python 2.7 does not support
-            # years < 1900, see OGD-751 and the time docs
-            # https://docs.python.org/2.7/library/time.html
-            epoch = datetime(1970, 1, 1)
-            return int((d - epoch).total_seconds())
-        except (ValueError, KeyError, TypeError, IndexError):
+            dt = isodate.parse_datetime(datetime_value)
+            if isinstance(dt, datetime):
+                return datetime_value
+        except Exception:
             return None
 
     def _get_eu_accrual_periodicity(self, subject, predicate):
@@ -309,7 +308,9 @@ class SwissDCATAPProfile(MultiLangProfile):
         ):
             value = self._object_value(dataset_ref, predicate)
             if value:
-                dataset_dict[key] = self._clean_datetime(value)
+                cleaned_value = self._clean_datetime(value)
+                if cleaned_value:
+                    dataset_dict[key] = cleaned_value
 
         # Multilingual basic fields
         for key, predicate in (
@@ -409,7 +410,9 @@ class SwissDCATAPProfile(MultiLangProfile):
             ):
                 value = self._object_value(distribution, predicate)
                 if value:
-                    resource_dict[key] = self._clean_datetime(value)
+                    cleaned_value = self._clean_datetime(value)
+                    if cleaned_value:
+                        resource_dict[key] = cleaned_value
 
             # Multilingual fields
             for key, predicate in (

--- a/ckanext/dcatapchharvest/tests/test_swiss_dcatap_profile_parse.py
+++ b/ckanext/dcatapchharvest/tests/test_swiss_dcatap_profile_parse.py
@@ -75,20 +75,16 @@ class TestSwissDCATAPProfileParsing(BaseParseTest):
                                                                {'name': 'statistische-grundlagen-und-ubersichten'}])
 
         #  Simple values
-        eq_(dataset['issued'], -2177539200)
-        eq_(dataset['modified'], 1524528000)
+        eq_(dataset['issued'], u'1900-12-31T00:00:00')
+        eq_(dataset['modified'], u'2018-04-24T19:30:57.197374')
         eq_(dataset['identifier'], u'346266@bundesamt-fur-statistik-bfs')
         eq_(dataset['spatial'], 'Schweiz')
 
         # Temporals
         temporal = dataset['temporals'][0]
-        eq_(temporal['end_date'], -2146003200)
-        end_date = datetime.fromtimestamp(temporal['end_date'])
-        eq_(end_date.date().isoformat(), '1901-12-31')
+        eq_(temporal['end_date'], u'1901-12-31T00:00:00')
 
-        eq_(temporal['start_date'], -2177452800)
-        start_date = datetime.fromtimestamp(temporal['start_date'])
-        eq_(start_date.date().isoformat(), '1901-01-01')
+        eq_(temporal['start_date'], u'1901-01-01T00:00:00')
 
         # Publisher
         publisher = json.loads(dataset['publisher'])
@@ -127,7 +123,7 @@ class TestSwissDCATAPProfileParsing(BaseParseTest):
         eq_(resource['identifier'], u'346265-fr@bundesamt-fur-statistik-bfs')
         eq_(resource['rights'], u'NonCommercialAllowed-CommercialWithPermission-ReferenceRequired')
         eq_(resource['language'], [u'fr'])
-        eq_(resource['issued'], -2177539200)
+        eq_(resource['issued'], u'1900-12-31T00:00:00')
         eq_(resource['url'], u'https://www.bfs.admin.ch/asset/fr/hs-b-00.01-jb-1901')
         assert 'download_url' not in resource, "download_url not available on resource"
 
@@ -149,13 +145,9 @@ class TestSwissDCATAPProfileParsing(BaseParseTest):
         dataset = datasets[0]
 
         # Check date values
-        eq_(dataset['issued'], -2398377600)
-        issued = datetime.fromtimestamp(dataset['issued'])
-        eq_(issued.date().isoformat(), u'1893-12-31')
+        eq_(dataset['issued'], u'1893-12-31T00:00:00')
 
-        eq_(dataset['modified'], 1524528000)
-        modified = datetime.fromtimestamp(dataset['modified'])
-        eq_(modified.date().isoformat(), u'2018-04-24')
+        eq_(dataset['modified'], u'2018-04-24T19:30:57.197374')
 
     def test_catalog(self):
 


### PR DESCRIPTION
since the dates are imported as isodates and also stored as
isodates, it is better to validate these isodates before they are
added to the dataset dictionary:

- we only set date field if they are valid, otherwise the property
  will not be set

- that way the import will not fail

- the data publisher can check his dates if he notices that
  they are missing on the dataset: this better then not importing
  the dataset

before:

- the dates were also cleand and transformed to numeric timestamps
- the transformation is now unnecessary as the dates are now stored
  as isodates
- if the dates were invalid they were returned as None which caused
  the dataset import to fail
- for some reason the import failed sometimes silent and was not
  reported