### PR TITLE
feat: harvester writes custom activity when a dataset has changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,4 @@ rights.
 
 Both configurations only work on the first import. Once imported the harvest 
 source must be cleared in order to prevent the import.
+

--- a/ckanext/dcatapchharvest/harvest_helper.py
+++ b/ckanext/dcatapchharvest/harvest_helper.py
@@ -1,0 +1,80 @@
+import ckan.plugins.toolkit as tk
+import ckan.model as model
+from dateutil.parser import parse as dateutil_parse
+import json
+
+import logging
+
+log = logging.getLogger(__name__)
+
+NOTIFICATION_USER = 'admin'
+
+
+def map_resources_to_ids(pkg_dict, package_id):
+    existing_package = \
+        tk.get_action('package_show')({}, {'id': package_id})
+    existing_resources = existing_package.get('resources')
+    existing_resources_mapping = \
+        {r['id']: _get_resource_id_string(r) for r in existing_resources}
+    for resource in pkg_dict.get('resources'):
+        resource_id_dict = _get_resource_id_string(resource)
+        id_to_reuse = [k for k, v in existing_resources_mapping.items()
+                       if v == resource_id_dict]
+        if id_to_reuse:
+            id_to_reuse = id_to_reuse[0]
+            resource['id'] = id_to_reuse
+            del existing_resources_mapping[id_to_reuse]
+    return existing_package
+
+
+def create_activity(package_id):
+    notification_user = tk.get_action('user_show')({}, {'id': NOTIFICATION_USER})
+    activity_dict = {
+        'user_id': notification_user['id'],
+        'object_id': package_id,
+        'activity_type': 'changed package',
+    }
+    activity_create_context = {
+        'model': model,
+        'user': NOTIFICATION_USER,
+        'defer_commit': True,
+        'ignore_auth': True,
+        'session': model.Session
+    }
+    tk.get_action('activity_create')(activity_create_context, activity_dict)
+
+
+def check_package_change(existing_pkg, dataset_dict):
+    if _changes_in_date(existing_pkg['modified'], dataset_dict['modified']):
+        return True
+    if len(existing_pkg.get('resources')) != len(dataset_dict.get('resources')):
+        return True
+    for resource in dataset_dict.get('resources'):
+        matching_existing_resource = [existing_resource for existing_resource in existing_pkg['resources']
+                                      if existing_resource['id'] == resource['id']]
+        if not matching_existing_resource:
+            return True
+        matching_existing_resource = matching_existing_resource[0]
+        if matching_existing_resource.get('url') != resource.get('url'):
+            return True
+        if matching_existing_resource.get('download_url') != resource.get('download_url'):
+            return True
+        if _changes_in_date(matching_existing_resource.get('modified'), resource.get('modified')):
+            return True
+    return False
+
+
+def _get_resource_id_string(resource):
+    return resource.get('url')
+
+
+def _changes_in_date(ogdch_date, isodate_date):
+    if not ogdch_date and not isodate_date:
+        return False
+    if not ogdch_date or not isodate_date:
+        return True
+    datetime_from_ogdch_date = dateutil_parse(ogdch_date, dayfirst=True)
+    datetime_from_isodate_date = dateutil_parse(isodate_date)
+    if datetime_from_ogdch_date.date() == datetime_from_isodate_date.date():
+        return False
+    return True

--- a/ckanext/dcatapchharvest/harvesters.py
+++ b/ckanext/dcatapchharvest/harvesters.py
@@ -3,10 +3,16 @@ import json
 import ckan.plugins as p
 import ckan.logic as logic
 import ckan.model as model
+import ckan.plugins.toolkit as tk
 
 from ckanext.dcat.harvesters.rdf import DCATRDFHarvester
 from ckanext.dcat.interfaces import IDCATRDFHarvester
 from ckanext.dcatapchharvest.dcat_helpers import get_pagination
+from ckanext.dcatapchharvest.harvest_helper import (
+    map_resources_to_ids,
+    check_package_change,
+    create_activity,
+)
 
 import logging
 log = logging.getLogger(__name__)
@@ -147,30 +153,9 @@ class SwissDCATRDFHarvester(DCATRDFHarvester):
             pass
 
     def before_update(self, harvest_object, dataset_dict, temp_dict):
-        # get existing pkg_dict with incoming pkg_name
-        site_user = logic.get_action('get_site_user')(
-            {'model': model, 'ignore_auth': True}, {})
-        context = {
-            'model': model,
-            'session': model.Session,
-            'ignore_auth': True,
-            'user': site_user['name'],
-        }
-        existing_pkg = p.toolkit.get_action('package_show')(context, {
-            'id': dataset_dict.get('name')})
-
-        # get existing resource-identifiers
-        existing_resources = existing_pkg.get('resources')
-        resource_mapping = {r.get('identifier'): r.get('id') for r in existing_resources if r.get('identifier')}  # noqa
-
-        # Try to match existing identifiers with new ones
-        # Note: in ckanext-dcat a mapping is already done based on the URI
-        #       which will be overwritten here, i.e. the mapping by identifier
-        #       has precedence
-        for resource in dataset_dict.get('resources'):
-            identifier = resource.get('identifier')
-            if identifier and identifier in resource_mapping:
-                resource['id'] = resource_mapping[identifier]
+        existing_pkg = map_resources_to_ids(dataset_dict, dataset_dict['name'])
+        if check_package_change(existing_pkg, dataset_dict):
+            create_activity(package_id=dataset_dict['id'])
 
     def after_download(self, content, harvest_job):
         if not content:

--- a/ckanext/dcatapchharvest/harvesters.py
+++ b/ckanext/dcatapchharvest/harvesters.py
@@ -1,9 +1,7 @@
 import json
 
 import ckan.plugins as p
-import ckan.logic as logic
 import ckan.model as model
-import ckan.plugins.toolkit as tk
 
 from ckanext.dcat.harvesters.rdf import DCATRDFHarvester
 from ckanext.dcat.interfaces import IDCATRDFHarvester


### PR DESCRIPTION
this feature customizes the check on when a dataset has changed when a change of the dataset is detected the user harvest-notifictaion cretaes and activity of type 'package changed'

Use case:
These activities can be used to trigger notifications in ckanext-subscribe rather then the automatically generated activities by the user harvest

Since the activity type is a fixed vocabulary in CKAN 2.8 the filtering needs to be done by the user who creates the activity rather than by the activity type