### PR TITLE
feat: Accept DCAT.startDate and DCAT.endDate for temporals

### DIFF
--- a/ckanext/dcatapchharvest/profiles.py
+++ b/ckanext/dcatapchharvest/profiles.py
@@ -235,10 +235,19 @@ class SwissDCATAPProfile(MultiLangProfile):
         temporals = []
 
         for temporal_node in self.g.objects(subject, predicate):
-            start_date = self._object_value(temporal_node, SCHEMA.startDate)
-            end_date = self._object_value(temporal_node, SCHEMA.endDate)
+            # Currently specified formats in DCAT-AP.
+            start_date = self._object_value(temporal_node, DCAT.startDate)
+            end_date = self._object_value(temporal_node, DCAT.endDate)
+            if not start_date or not end_date:
+                # Previously specified formats in DCAT-AP. Should still be
+                # accepted.
+                start_date = self._object_value(
+                    temporal_node, SCHEMA.startDate)
+                end_date = self._object_value(
+                    temporal_node, SCHEMA.endDate)
             if not start_date or not end_date:
                 continue
+
             cleaned_start_date = self._clean_datetime(start_date)
             cleaned_end_date = self._clean_datetime(end_date)
             if not cleaned_start_date or not cleaned_end_date:


### PR DESCRIPTION
The SCHEMA.startDate and SCHEMA.endDate predicates were originally used by DCAT-AP for temporals, but now they have switched to using DCAT.startDate and DCAT.endDate, in line with DCAT. We should accept both.