### PR TITLE
feat: Export temporals with DCAT.startDate and DCAT.endDate

### DIFF
--- a/ckanext/dcatapchharvest/profiles.py
+++ b/ckanext/dcatapchharvest/profiles.py
@@ -599,13 +599,13 @@ class SwissDCATAPProfile(MultiLangProfile):
                     if start:
                         self._add_date_triple(
                             temporal_extent,
-                            SCHEMA.startDate,
+                            DCAT.startDate,
                             start
                         )
                     if end:
                         self._add_date_triple(
                             temporal_extent,
-                            SCHEMA.endDate,
+                            DCAT.endDate,
                             end
                         )
                     g.add((dataset_ref, DCT.temporal, temporal_extent))


### PR DESCRIPTION
This is to be conformant with DCAT-AP, which originally used SCHEMA.startDate and SCHEMA.endDate, but then switched to DCAT.