### PR TITLE
fix: Handle identifiers with non-ascii characters

### DIFF
--- a/ckanext/dcatapchharvest/dcat_helpers.py
+++ b/ckanext/dcatapchharvest/dcat_helpers.py
@@ -82,8 +82,8 @@ def dataset_uri(dataset_dict, dataset_ref=None):
                 break
     if not uri:
         site_url = config.get('ckan.site_url')
-        uri = '{0}/perma/{1}'.format(site_url,
-                                     dataset_dict.get('identifier'))
+        uri = u'{0}/perma/{1}'.format(site_url,
+                                      dataset_dict.get('identifier'))
 
     return uri
 


### PR DESCRIPTION
The dataset identifier might contain a non-ascii character (e.g. Statdpräsidentinnen@some-city-name), so the uri needs to be a unicode string.