### PR TITLE
feat: map eu vocabulary to format for RDF export

### DIFF
--- a/ckanext/dcatapchharvest/profiles.py
+++ b/ckanext/dcatapchharvest/profiles.py
@@ -889,12 +889,24 @@ class SwissDCATAPProfile(MultiLangProfile):
 
             # Format
             if resource_dict.get('format'):
+<<<<<<< Updated upstream
                 g.add((
                     distribution,
                     DCT['format'],
                     Literal(resource_dict['format'])
                 ))
 
+=======
+                for key, value in valid_formats.items():
+                    if resource_dict.get('format') == key:
+                        format_uri = URIRef(value)
+                        g.add((
+                            distribution,
+                            DCT['format'],
+                            format_uri
+                        ))
+                        
+>>>>>>> Stashed changes
             # Mime-Type
             if resource_dict.get('mimetype'):
                 g.add((

--- a/ckanext/dcatapchharvest/tests/fixtures/dataset.json
+++ b/ckanext/dcatapchharvest/tests/fixtures/dataset.json
@@ -106,7 +106,8 @@
         "https://example.com/documentation-resource-2"
       ],
       "rights": "Creative Commons CC Zero License (cc-zero)",
-      "license": "NonCommercialAllowed-CommercialAllowed-ReferenceNotRequired"
+      "license": "NonCommercialAllowed-CommercialAllowed-ReferenceNotRequired",
+      "format": "CSV"
     },
     {
       "id": "28e75e40-e1a1-497b-a1b9-8c1834d60201",
@@ -116,7 +117,8 @@
         "https://example.com/documentation-resource-2"
       ],
       "rights": "http://dcat-ap.ch/vocabulary/licenses/terms_by",
-      "license": "NonCommercialAllowed-CommercialAllowed-ReferenceRequired"
+      "license": "NonCommercialAllowed-CommercialAllowed-ReferenceRequired",
+      "format": "HTML"
     },
     {
       "id": "0cfce6ba-28f4-4229-b733-f6492c650395",
@@ -126,7 +128,8 @@
         "https://example.com/documentation-resource-2"
       ],
       "rights": "http://dcat-ap.ch/vocabulary/licenses/terms_by_ask",
-      "license": "http://dcat-ap.ch/vocabulary/licenses/cc-by/4.0"
+      "license": "http://dcat-ap.ch/vocabulary/licenses/cc-by/4.0",
+      "format": "JSON"
     }
   ],
   "extras": [

--- a/ckanext/dcatapchharvest/tests/test_dcatap_ch_serialize.py
+++ b/ckanext/dcatapchharvest/tests/test_dcatap_ch_serialize.py
@@ -78,7 +78,7 @@ class TestDCATAPCHProfileSerializeDataset(BaseSerializeTest):
             distribution = URIRef(dh.resource_uri(resource_dict))
             assert self._triple(g, distribution, RDF.type, DCAT.Distribution)
             for link in resource_dict.get("documentation", []):
-                assert self._triple(g, distribution, FOAF.page, URIRef(link))       
+                assert self._triple(g, distribution, FOAF.page, URIRef(link))   
             
             #e2c50e70-67ad-4f86-bb1b-3f93867eadaa    
             if resource_dict.get('rights') == 'Creative Commons CC Zero License (cc-zero)':
@@ -90,7 +90,7 @@ class TestDCATAPCHProfileSerializeDataset(BaseSerializeTest):
                 
             #28e75e40-e1a1-497b-a1b9-8c1834d60201
             if resource_dict.get('rights') == "http://dcat-ap.ch/vocabulary/licenses/terms_by":
-                assert self._triple(g, distribution, DCT.rights, URIRef("http://dcat-ap.ch/vocabulary/licenses/terms_by"))    
+                assert self._triple(g, distribution, DCT.rights, URIRef("http://dcat-ap.ch/vocabulary/licenses/terms_by"))
                 
             if resource_dict.get('license') == "NonCommercialAllowed-CommercialAllowed-ReferenceRequired":
                 assert self._triple(g, distribution, DCT.license, URIRef("http://dcat-ap.ch/vocabulary/licenses/terms_by"))
@@ -101,9 +101,16 @@ class TestDCATAPCHProfileSerializeDataset(BaseSerializeTest):
                 assert self._triple(g, distribution, DCT.rights, URIRef("http://dcat-ap.ch/vocabulary/licenses/terms_by_ask"))
                 
             if resource_dict.get('license') == "http://dcat-ap.ch/vocabulary/licenses/cc-by/4.0":
-                assert self._triple(g, distribution, DCT.license, URIRef("http://dcat-ap.ch/vocabulary/licenses/cc-by/4.0"))    
-            
+                assert self._triple(g, distribution, DCT.license, URIRef("http://dcat-ap.ch/vocabulary/licenses/cc-by/4.0"))
+
+            if resource_dict.get('format') == "CSV":
+                assert self._triple(g, distribution, DCT['format'], URIRef("http://publications.europa.eu/resource/authority/file-type/CSV"))
                 
+            if resource_dict.get('format') == "HTML":
+                assert self._triple(g, distribution, DCT['format'], URIRef("http://publications.europa.eu/resource/authority/file-type/HTML"))
+                
+            if resource_dict.get('format') == "JSON":
+                assert self._triple(g, distribution, DCT['format'], URIRef("http://publications.europa.eu/resource/authority/file-type/JSON"))
 
                 
     def test_graph_from_dataset_uri(self):


### PR DESCRIPTION
The format is exported as URI using of the standardised formats from the vocabulary http://publications.europa.eu/resource/authority/file-type for RDF Export.
If there is no matching URI, we don't output any value for the format.