### PR TITLE
feat: extend format mapping for geocat format

### DIFF
--- a/ckanext/dcatapchharvest/profiles.py
+++ b/ckanext/dcatapchharvest/profiles.py
@@ -967,7 +967,7 @@ class SwissDCATAPProfile(MultiLangProfile):
         # Format: Set Format value if format matches EU vocabulary
         format_uri = None
         if resource_dict.get('format'):
-            format = resource_dict.get('format')
+            format = resource_dict.get('format').replace(' ', '_')
             if format in valid_formats:
                 format_uri = URIRef(valid_formats[format])
                 g.add((distribution, DCT['format'], format_uri))


### PR DESCRIPTION
Adjust format mapping for generating the graph from dataset, so that there are more matches possible for geocat format data.