### PR TITLE
Update outputs of the Licenses and Rights  

### DIFF
--- a/ckanext/dcatapchharvest/dcat_helpers.py
+++ b/ckanext/dcatapchharvest/dcat_helpers.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 DCT = Namespace("http://purl.org/dc/terms/")
 EUTHEMES = \
     Namespace("http://publications.europa.eu/resource/authority/data-theme/")
-FOAF = Namespace("http://xmlns.com/foaf/0.1/") # noqa
+FOAF = Namespace("http://xmlns.com/foaf/0.1/")
 HYDRA = Namespace('http://www.w3.org/ns/hydra/core#')
 
 SKOSXL = Namespace("http://www.w3.org/2008/05/skos-xl#")

--- a/ckanext/dcatapchharvest/dcat_helpers.py
+++ b/ckanext/dcatapchharvest/dcat_helpers.py
@@ -284,48 +284,6 @@ class LicenseHandler:
                     None)
 
 
-def get_license_values():
-    g = Graph()
-    license_ref_literal_mapping = {}
-    license_homepages_literal_mapping = {}
-    license_homepage_ref_mapping = {}
-
-    for prefix, namespace in license_namespaces.items():
-        g.bind(prefix, namespace)
-    file = os.path.join(__location__, 'license.ttl')
-    g.parse(file, format='turtle')
-    for ogdch_license_ref in g.subjects(predicate=RDF.type,
-                                        object=SKOS.Concept):
-        license_homepage = None
-        for homepage in g.objects(subject=ogdch_license_ref,
-                                  predicate=FOAF.homepage):
-            license_homepage = homepage
-            break  # Assume one homepage per concept
-
-        license_literal = None
-        try:
-            for license_pref_label in g.objects(subject=ogdch_license_ref,
-                                                predicate=SKOSXL.prefLabel):
-                license_literal = next(g.objects(subject=license_pref_label,
-                                                 predicate=SKOSXL.literalForm))
-                if license_literal is not None:
-                    break  # Assume one literal per concept
-
-            license_homepages_literal_mapping[unicode(license_homepage)] = \
-                unicode(license_literal)
-            license_ref_literal_mapping[unicode(ogdch_license_ref)] = \
-                unicode(license_literal)
-            license_homepage_ref_mapping[unicode(license_homepage)] = \
-                unicode(ogdch_license_ref)
-
-        except Exception as e:
-            raise ValueError("SKOSXL.prefLabel is missing in the RDF-file: %s"
-                             % e)
-
-    return (license_homepages_literal_mapping, license_ref_literal_mapping,
-            license_homepage_ref_mapping)
-
-
 def get_theme_mapping():
     g = Graph()
     theme_mapping = {}

--- a/ckanext/dcatapchharvest/dcat_helpers.py
+++ b/ckanext/dcatapchharvest/dcat_helpers.py
@@ -13,11 +13,11 @@ log = logging.getLogger(__name__)
 DCT = Namespace("http://purl.org/dc/terms/")
 EUTHEMES = \
     Namespace("http://publications.europa.eu/resource/authority/data-theme/")
+FOAF = Namespace("http://xmlns.com/foaf/0.1/") # noqa
 HYDRA = Namespace('http://www.w3.org/ns/hydra/core#')
 
 SKOSXL = Namespace("http://www.w3.org/2008/05/skos-xl#")
 RDFS = Namespace("http://www.w3.org/2000/01/rdf-schema#")
-FOAF = Namespace("http://xmlns.com/foaf/0.1/")
 
 frequency_namespaces = {
   "skos": SKOS,

--- a/ckanext/dcatapchharvest/dcat_helpers.py
+++ b/ckanext/dcatapchharvest/dcat_helpers.py
@@ -219,7 +219,6 @@ class LicenseHandler:
         return (license_homepages_literal_mapping,
                 license_ref_literal_mapping, license_homepage_ref_mapping)
 
-
     def _get_license_values(self):
         if self._license_cache is None:
             try:
@@ -227,9 +226,10 @@ class LicenseHandler:
                 self._bind_namespaces(g)
                 self._parse_graph(g)
 
-                license_homepages_literal_mapping, \
-                license_ref_literal_mapping, \
-                license_homepage_ref_mapping = self._process_graph(g)
+                (license_homepages_literal_mapping,
+                 license_ref_literal_mapping,
+                 license_homepage_ref_mapping) = self._process_graph(g)
+
                 self._license_cache = (license_homepages_literal_mapping,
                                        license_ref_literal_mapping,
                                        license_homepage_ref_mapping)

--- a/ckanext/dcatapchharvest/dcat_helpers.py
+++ b/ckanext/dcatapchharvest/dcat_helpers.py
@@ -243,11 +243,10 @@ def get_license_values():
         try:
             for license_pref_label in g.objects(subject=ogdch_license_ref,
                                                 predicate=SKOSXL.prefLabel):
-                for literal in g.objects(subject=license_pref_label,
-                                         predicate=SKOSXL.literalForm):
-                    license_literal = literal
+                license_literal = next(g.objects(subject=license_pref_label,
+                                                 predicate=SKOSXL.literalForm))
+                if license_literal is not None:
                     break  # Assume one literal per concept
-
             license_homepages_literal_mapping[license_homepage] = license_literal  # noqa
             license_ref_literal_mapping[ogdch_license_ref] = license_literal
             license_homepage_ref_mapping[license_homepage] = ogdch_license_ref

--- a/ckanext/dcatapchharvest/dcat_helpers.py
+++ b/ckanext/dcatapchharvest/dcat_helpers.py
@@ -4,7 +4,7 @@ import os
 from urlparse import urlparse
 from ckantoolkit import config
 from rdflib import URIRef, Graph
-from rdflib.namespace import Namespace, RDF, SKOS, FOAF
+from rdflib.namespace import Namespace, RDF, SKOS
 import xml.etree.ElementTree as ET
 import logging
 

--- a/ckanext/dcatapchharvest/dcat_helpers.py
+++ b/ckanext/dcatapchharvest/dcat_helpers.py
@@ -172,7 +172,7 @@ def get_frequency_values():
 def get_license_ref_uri_by_name(vocabulary_name):
     _, license_ref_literal_vocabulary, _ = get_license_values()
     for key, value in license_ref_literal_vocabulary.items():
-        if unicode(vocabulary_name) == unicode(value):
+        if vocabulary_name == value:
             return key
     return None
 
@@ -180,7 +180,7 @@ def get_license_ref_uri_by_name(vocabulary_name):
 def get_license_ref_uri_by_homepage_uri(vocabulary_name):
     _, _, license_homepage_ref_vocabulary = get_license_values()
     for key, value in license_homepage_ref_vocabulary.items():
-        if unicode(vocabulary_name) == unicode(key):
+        if vocabulary_name == key:
             return value
     return None
 
@@ -188,23 +188,23 @@ def get_license_ref_uri_by_homepage_uri(vocabulary_name):
 def get_license_name_by_ref_uri(vocabulary_uri):
     _, license_ref_literal_vocabulary, _ = get_license_values()
     for key, value in license_ref_literal_vocabulary.items():
-        if unicode(vocabulary_uri) == unicode(key):
-            return unicode(value)
+        if vocabulary_uri == key:
+            return value
     return None
 
 
 def get_license_name_by_homepage_uri(vocabulary_uri):
     license_homepages_literal_vocabulary, _, _ = get_license_values()
     for key, value in license_homepages_literal_vocabulary.items():
-        if unicode(vocabulary_uri) == unicode(key):
-            return unicode(value)
+        if vocabulary_uri == key:
+            return value
     return None
 
 
 def get_license_homepage_uri_by_name(vocabulary_name):
     license_homepages_literal_vocabulary, _, _ = get_license_values()
     for key, value in license_homepages_literal_vocabulary.items():
-        if unicode(vocabulary_name) == unicode(value):
+        if vocabulary_name == value:
             return key
     return None
 
@@ -213,12 +213,12 @@ def get_license_homepage_uri_by_uri(vocabulary_uri):
     _, _, license_homepage_ref_vocabulary = get_license_values()
     license_homepages = list(license_homepage_ref_vocabulary.keys())
     if vocabulary_uri in license_homepages:
-        return unicode(vocabulary_uri)
+        return vocabulary_uri
     else:
         for key, value in license_homepage_ref_vocabulary.items():
-            if unicode(vocabulary_uri) == unicode(value):
-                return unicode(key)
-    return
+            if vocabulary_uri == value:
+                return key
+    return None
 
 
 def get_license_values():
@@ -247,9 +247,13 @@ def get_license_values():
                                                  predicate=SKOSXL.literalForm))
                 if license_literal is not None:
                     break  # Assume one literal per concept
-            license_homepages_literal_mapping[license_homepage] = license_literal  # noqa
-            license_ref_literal_mapping[ogdch_license_ref] = license_literal
-            license_homepage_ref_mapping[license_homepage] = ogdch_license_ref
+
+            license_homepages_literal_mapping[unicode(license_homepage)] = \
+                unicode(license_literal)
+            license_ref_literal_mapping[unicode(ogdch_license_ref)] = \
+                unicode(license_literal)
+            license_homepage_ref_mapping[unicode(license_homepage)] = \
+                unicode(ogdch_license_ref)
 
         except Exception as e:
             raise ValueError("SKOSXL.prefLabel is missing in the RDF-file: %s"

--- a/ckanext/dcatapchharvest/dcat_helpers.py
+++ b/ckanext/dcatapchharvest/dcat_helpers.py
@@ -247,24 +247,17 @@ class LicenseHandler:
 
     def get_license_ref_uri_by_homepage_uri(self, vocabulary_name):
         _, _, license_homepage_ref_vocabulary = self._get_license_values()
-        return next((value for key, value in
-                     license_homepage_ref_vocabulary.items()
-                     if unicode(vocabulary_name) == key),
-                    None)
+        return license_homepage_ref_vocabulary.get(unicode(vocabulary_name))
 
     def get_license_name_by_ref_uri(self, vocabulary_uri):
         _, license_ref_literal_vocabulary, _ = self._get_license_values()
-        return next((value for key, value in
-                     license_ref_literal_vocabulary.items()
-                     if unicode(vocabulary_uri) == key),
-                    None)
+        return license_ref_literal_vocabulary.get(
+            unicode(vocabulary_uri))
 
     def get_license_name_by_homepage_uri(self, vocabulary_uri):
         license_homepages_literal_vocabulary, _, _ = self._get_license_values()
-        return next((value for key, value in
-                     license_homepages_literal_vocabulary.items()
-                     if unicode(vocabulary_uri) == key),
-                    None)
+        return license_homepages_literal_vocabulary.get(
+            unicode(vocabulary_uri))
 
     def get_license_homepage_uri_by_name(self, vocabulary_name):
         license_homepages_literal_vocabulary, _, _ = self._get_license_values()

--- a/ckanext/dcatapchharvest/dcat_helpers.py
+++ b/ckanext/dcatapchharvest/dcat_helpers.py
@@ -172,7 +172,7 @@ def get_frequency_values():
 def get_license_ref_uri_by_name(vocabulary_name):
     _, license_ref_literal_vocabulary, _ = get_license_values()
     for key, value in license_ref_literal_vocabulary.items():
-        if vocabulary_name == value:
+        if unicode(vocabulary_name) == value:
             return key
     return None
 
@@ -180,7 +180,7 @@ def get_license_ref_uri_by_name(vocabulary_name):
 def get_license_ref_uri_by_homepage_uri(vocabulary_name):
     _, _, license_homepage_ref_vocabulary = get_license_values()
     for key, value in license_homepage_ref_vocabulary.items():
-        if vocabulary_name == key:
+        if unicode(vocabulary_name) == key:
             return value
     return None
 
@@ -188,7 +188,7 @@ def get_license_ref_uri_by_homepage_uri(vocabulary_name):
 def get_license_name_by_ref_uri(vocabulary_uri):
     _, license_ref_literal_vocabulary, _ = get_license_values()
     for key, value in license_ref_literal_vocabulary.items():
-        if vocabulary_uri == key:
+        if unicode(vocabulary_uri) == key:
             return value
     return None
 
@@ -196,7 +196,7 @@ def get_license_name_by_ref_uri(vocabulary_uri):
 def get_license_name_by_homepage_uri(vocabulary_uri):
     license_homepages_literal_vocabulary, _, _ = get_license_values()
     for key, value in license_homepages_literal_vocabulary.items():
-        if vocabulary_uri == key:
+        if unicode(vocabulary_uri) == key:
             return value
     return None
 
@@ -204,7 +204,7 @@ def get_license_name_by_homepage_uri(vocabulary_uri):
 def get_license_homepage_uri_by_name(vocabulary_name):
     license_homepages_literal_vocabulary, _, _ = get_license_values()
     for key, value in license_homepages_literal_vocabulary.items():
-        if vocabulary_name == value:
+        if unicode(vocabulary_name) == value:
             return key
     return None
 
@@ -212,11 +212,11 @@ def get_license_homepage_uri_by_name(vocabulary_name):
 def get_license_homepage_uri_by_uri(vocabulary_uri):
     _, _, license_homepage_ref_vocabulary = get_license_values()
     license_homepages = list(license_homepage_ref_vocabulary.keys())
-    if vocabulary_uri in license_homepages:
-        return vocabulary_uri
+    if unicode(vocabulary_uri) in license_homepages:
+        return unicode(vocabulary_uri)
     else:
         for key, value in license_homepage_ref_vocabulary.items():
-            if vocabulary_uri == value:
+            if unicode(vocabulary_uri) == value:
                 return key
     return None
 

--- a/ckanext/dcatapchharvest/license.ttl
+++ b/ckanext/dcatapchharvest/license.ttl
@@ -46,7 +46,7 @@
     skosxl:literalForm "NonCommercialAllowed-CommercialAllowed-ReferenceRequired"@en ;
     rdfs:label "NonCommercialAllowed-CommercialAllowed-ReferenceRequired"@de
   ] ;
-  foaf:homepage <https://opendata.swiss/en/terms-of-use/#terms_by> .
+  foaf:homepage <https://opendata.swiss/terms-of-use/#terms_by> .
 
 <http://dcat-ap.ch/vocabulary/licenses/terms_ask>
   a skos:Concept ;
@@ -61,7 +61,7 @@
     skosxl:literalForm "NonCommercialAllowed-CommercialWithPermission-ReferenceNotRequired"@en ;
     rdfs:label "NonCommercialAllowed-CommercialWithPermission-ReferenceNotRequired"@de
   ] ;
-  foaf:homepage <https://opendata.swiss/en/terms-of-use/#terms_ask> .
+  foaf:homepage <https://opendata.swiss/terms-of-use/#terms_ask> .
 
 <http://dcat-ap.ch/vocabulary/licenses/terms_by_ask>
   a skos:Concept ;
@@ -76,7 +76,7 @@
     skosxl:literalForm "NonCommercialAllowed-CommercialWithPermission-ReferenceRequired"@en ;
     rdfs:label "NonCommercialAllowed-CommercialWithPermission-ReferenceRequired"@de
   ] ;
-  foaf:homepage <https://opendata.swiss/en/terms-of-use/#terms_by_ask> .
+  foaf:homepage <https://opendata.swiss/terms-of-use/#terms_by_ask> .
 
 <https://creativecommons.org/publicdomain/zero/1.0/>
   a skos:Concept, cc:License ;

--- a/ckanext/dcatapchharvest/profiles.py
+++ b/ckanext/dcatapchharvest/profiles.py
@@ -1035,7 +1035,7 @@ class SwissDCATAPProfile(MultiLangProfile):
     def _rights_and_license_to_graph(self, resource_dict, distribution):
         g = self.g
         if resource_dict.get('rights'):
-            rights_uri = dh.get_license_uri_by_name(
+            rights_uri = dh.get_license_ref_uri_by_homepage_uri(
                 resource_dict.get('rights')
             )
             if rights_uri is not None:
@@ -1043,13 +1043,12 @@ class SwissDCATAPProfile(MultiLangProfile):
                 g.add((rights_ref, RDF.type, DCT.RightsStatement))
                 g.add((distribution, DCT.rights, rights_ref))
             if rights_uri is None:
-                rights_name = dh.get_license_name_by_uri(
+                rights_name = dh.get_license_name_by_homepage_uri(
                     resource_dict.get('rights')
                     )
                 if rights_name is not None:
-                    resource_rights_ref = URIRef(
-                        resource_dict.get('rights')
-                        )
+                    resource_rights_ref = dh.get_license_ref_uri_by_name(
+                        rights_name)
                     g.add((
                         resource_rights_ref,
                         RDF.type,
@@ -1058,7 +1057,7 @@ class SwissDCATAPProfile(MultiLangProfile):
                     g.add((distribution, DCT.rights, resource_rights_ref))
 
         if resource_dict.get('license'):
-            license_uri = dh.get_license_uri_by_name(
+            license_uri = dh.get_license_ref_uri_by_homepage_uri(
                 resource_dict.get('license')
             )
             if license_uri is not None:
@@ -1066,13 +1065,12 @@ class SwissDCATAPProfile(MultiLangProfile):
                 g.add((license_ref, RDF.type, DCT.LicenseDocument))
                 g.add((distribution, DCT.license, license_ref))
             if license_uri is None:
-                license_name = dh.get_license_name_by_uri(
+                license_name = dh.get_license_name_by_homepage_uri(
                     resource_dict.get('license')
                     )
                 if license_name is not None:
-                    resource_license_ref = URIRef(
-                        resource_dict.get('license')
-                        )
+                    resource_license_ref = dh.get_license_ref_uri_by_name(
+                        license_name)
                     g.add((
                         resource_license_ref,
                         RDF.type,

--- a/ckanext/dcatapchharvest/profiles.py
+++ b/ckanext/dcatapchharvest/profiles.py
@@ -1054,7 +1054,6 @@ class SwissDCATAPProfile(MultiLangProfile):
             g.add((license_ref, RDF.type, DCT.LicenseDocument))
             g.add((distribution, DCT.license, license_ref))
 
-
     def _format_and_media_type_to_graph(self, resource_dict, distribution):
         g = self.g
         # Export format value if it matches EU vocabulary

--- a/ckanext/dcatapchharvest/profiles.py
+++ b/ckanext/dcatapchharvest/profiles.py
@@ -279,7 +279,7 @@ class SwissDCATAPProfile(MultiLangProfile):
 
     def _license_rights_homepage_uri(self, subject, predicate):
         for node in self.g.objects(subject, predicate):
-            # DCAT-AP CH v2 compatible license has to be a URI.
+            # Rights and license has to be a homepage URI
             if isinstance(node, Literal):
                 return dh.get_license_homepage_uri_by_name(node)
             if isinstance(node, URIRef):
@@ -1039,50 +1039,21 @@ class SwissDCATAPProfile(MultiLangProfile):
     def _rights_and_license_to_graph(self, resource_dict, distribution):
         g = self.g
         if resource_dict.get('rights'):
-            rights_uri = dh.get_license_ref_uri_by_homepage_uri(
+            rights_ref_uri = dh.get_license_ref_uri_by_homepage_uri(
                 resource_dict.get('rights')
             )
-            if rights_uri is not None:
-                rights_ref = URIRef(rights_uri)
-                g.add((rights_ref, RDF.type, DCT.RightsStatement))
-                g.add((distribution, DCT.rights, rights_ref))
-            if rights_uri is None:
-                rights_name = dh.get_license_name_by_homepage_uri(
-                    resource_dict.get('rights')
-                    )
-                if rights_name is not None:
-                    resource_rights_ref = dh.get_license_ref_uri_by_name(
-                        rights_name)
-                    g.add((
-                        resource_rights_ref,
-                        RDF.type,
-                        DCT.RightsStatement)
-                        )
-                    g.add((distribution, DCT.rights, resource_rights_ref))
+            rights_ref = URIRef(rights_ref_uri)
+            g.add((rights_ref, RDF.type, DCT.RightsStatement))
+            g.add((distribution, DCT.rights, rights_ref))
 
         if resource_dict.get('license'):
-            license_uri = dh.get_license_ref_uri_by_homepage_uri(
+            license_ref_uri = dh.get_license_ref_uri_by_homepage_uri(
                 resource_dict.get('license')
             )
-            if license_uri is not None:
-                license_ref = URIRef(license_uri)
-                g.add((license_ref, RDF.type, DCT.LicenseDocument))
-                g.add((distribution, DCT.license, license_ref))
-            if license_uri is None:
-                license_name = dh.get_license_name_by_homepage_uri(
-                    resource_dict.get('license')
-                    )
-                if license_name is not None:
-                    resource_license_ref = dh.get_license_ref_uri_by_name(
-                        license_name)
-                    g.add((
-                        resource_license_ref,
-                        RDF.type,
-                        DCT.LicenseDocument)
-                        )
-                    g.add(
-                        (distribution, DCT.license, resource_license_ref)
-                        )
+            license_ref = URIRef(license_ref_uri)
+            g.add((license_ref, RDF.type, DCT.LicenseDocument))
+            g.add((distribution, DCT.license, license_ref))
+
 
     def _format_and_media_type_to_graph(self, resource_dict, distribution):
         g = self.g

--- a/ckanext/dcatapchharvest/profiles.py
+++ b/ckanext/dcatapchharvest/profiles.py
@@ -646,6 +646,8 @@ class SwissDCATAPProfile(MultiLangProfile):
                 if 'cc' in license and 'cc' not in rights:
                     resource_dict['license'] = rights
                     resource_dict['rights'] = license
+                elif 'cc' in license and 'cc' in rights:
+                    resource_dict['license'] = None
             else:
                 resource_dict['license'] = None
                 resource_dict['rights'] = None

--- a/ckanext/dcatapchharvest/profiles.py
+++ b/ckanext/dcatapchharvest/profiles.py
@@ -279,7 +279,7 @@ class SwissDCATAPProfile(MultiLangProfile):
 
     def _license_rights_homepage_uri(self, subject, predicate):
         for node in self.g.objects(subject, predicate):
-            # Rights and license has to be a homepage URI
+            # DCAT-AP CH v2 compatible license has to be a URI.
             if isinstance(node, Literal):
                 return dh.get_license_homepage_uri_by_name(node)
             if isinstance(node, URIRef):
@@ -1039,20 +1039,50 @@ class SwissDCATAPProfile(MultiLangProfile):
     def _rights_and_license_to_graph(self, resource_dict, distribution):
         g = self.g
         if resource_dict.get('rights'):
-            rights_ref_uri = dh.get_license_ref_uri_by_homepage_uri(
+            rights_uri = dh.get_license_ref_uri_by_homepage_uri(
                 resource_dict.get('rights')
             )
-            rights_ref = URIRef(rights_ref_uri)
-            g.add((rights_ref, RDF.type, DCT.RightsStatement))
-            g.add((distribution, DCT.rights, rights_ref))
+            if rights_uri is not None:
+                rights_ref = URIRef(rights_uri)
+                g.add((rights_ref, RDF.type, DCT.RightsStatement))
+                g.add((distribution, DCT.rights, rights_ref))
+            if rights_uri is None:
+                rights_name = dh.get_license_name_by_homepage_uri(
+                    resource_dict.get('rights')
+                    )
+                if rights_name is not None:
+                    resource_rights_ref = dh.get_license_ref_uri_by_name(
+                        rights_name)
+                    g.add((
+                        resource_rights_ref,
+                        RDF.type,
+                        DCT.RightsStatement)
+                        )
+                    g.add((distribution, DCT.rights, resource_rights_ref))
 
         if resource_dict.get('license'):
-            license_ref_uri = dh.get_license_ref_uri_by_homepage_uri(
+            license_uri = dh.get_license_ref_uri_by_homepage_uri(
                 resource_dict.get('license')
             )
-            license_ref = URIRef(license_ref_uri)
-            g.add((license_ref, RDF.type, DCT.LicenseDocument))
-            g.add((distribution, DCT.license, license_ref))
+            if license_uri is not None:
+                license_ref = URIRef(license_uri)
+                g.add((license_ref, RDF.type, DCT.LicenseDocument))
+                g.add((distribution, DCT.license, license_ref))
+            if license_uri is None:
+                license_name = dh.get_license_name_by_homepage_uri(
+                    resource_dict.get('license')
+                    )
+                if license_name is not None:
+                    resource_license_ref = dh.get_license_ref_uri_by_name(
+                        license_name)
+                    g.add((
+                        resource_license_ref,
+                        RDF.type,
+                        DCT.LicenseDocument)
+                        )
+                    g.add(
+                        (distribution, DCT.license, resource_license_ref)
+                        )
 
     def _format_and_media_type_to_graph(self, resource_dict, distribution):
         g = self.g

--- a/ckanext/dcatapchharvest/profiles.py
+++ b/ckanext/dcatapchharvest/profiles.py
@@ -13,9 +13,8 @@ import ckanext.dcatapchharvest.dcat_helpers as dh
 from ckanext.dcat.profiles import CleanedURIRef, RDFProfile, SchemaOrgProfile
 
 log = logging.getLogger(__name__)
-
+license_handler = dh.LicenseHandler()
 valid_frequencies = dh.get_frequency_values()
-valid_licenses = dh.get_license_values()
 eu_theme_mapping = dh.get_theme_mapping()
 valid_formats = dh.get_format_values()
 valid_media_types = dh.get_iana_media_type_values()
@@ -281,9 +280,9 @@ class SwissDCATAPProfile(MultiLangProfile):
         for node in self.g.objects(subject, predicate):
             # DCAT-AP CH v2 compatible license has to be a URI.
             if isinstance(node, Literal):
-                return dh.get_license_homepage_uri_by_name(node)
+                return license_handler.get_license_homepage_uri_by_name(node)
             if isinstance(node, URIRef):
-                return dh.get_license_homepage_uri_by_uri(node)
+                return license_handler.get_license_homepage_uri_by_uri(node)
         return None
 
     def _keywords(self, subject):
@@ -1046,13 +1045,13 @@ class SwissDCATAPProfile(MultiLangProfile):
         if not homepage_uri:
             return None
 
-        uri = dh.get_license_ref_uri_by_homepage_uri(homepage_uri)
+        uri = license_handler.get_license_ref_uri_by_homepage_uri(homepage_uri)
         if uri is not None:
             return URIRef(uri)
 
-        name = dh.get_license_name_by_homepage_uri(homepage_uri)
+        name = license_handler.get_license_name_by_homepage_uri(homepage_uri)
         if name is not None:
-            uri = dh.get_license_ref_uri_by_name(name)
+            uri = license_handler.get_license_ref_uri_by_name(name)
             if uri is not None:
                 return URIRef(uri)
 

--- a/ckanext/dcatapchharvest/profiles.py
+++ b/ckanext/dcatapchharvest/profiles.py
@@ -624,8 +624,12 @@ class SwissDCATAPProfile(MultiLangProfile):
                     resource_dict[key] = value
 
             #  Rights & License save homepage uri
-            rights = self._license_rights_homepage_uri(distribution, DCT.rights)
-            license = self._license_rights_homepage_uri(distribution, DCT.license)
+            rights = self._license_rights_homepage_uri(
+                distribution, DCT.rights
+            )
+            license = self._license_rights_homepage_uri(
+                distribution, DCT.license
+            )
 
             if rights is None and license is not None:
                 resource_dict['license'] = license

--- a/ckanext/dcatapchharvest/tests/fixtures/dataset.json
+++ b/ckanext/dcatapchharvest/tests/fixtures/dataset.json
@@ -121,8 +121,8 @@
         "https://example.com/documentation-resource-1",
         "https://example.com/documentation-resource-2"
       ],
-      "rights": "Creative Commons Zero 1.0 Universell (CC0 1.0)",
-      "license": "NonCommercialAllowed-CommercialAllowed-ReferenceNotRequired",
+      "rights": "http://www.opendefinition.org/licenses/cc-zero",
+      "license": "https://opendata.swiss/terms-of-use/#terms_open",
       "format": "CSV",
       "issued": "2015-06-26T15:21:09.034694",
       "modified": "2015-06-30T15:21:09.000000"
@@ -135,7 +135,7 @@
         "https://example.com/documentation-resource-2"
       ],
       "rights": "http://dcat-ap.ch/vocabulary/licenses/terms_by",
-      "license": "NonCommercialAllowed-CommercialAllowed-ReferenceRequired",
+      "license": "https://opendata.swiss/en/terms-of-use/#terms_by",
       "format": "HTML"
     },
     {

--- a/ckanext/dcatapchharvest/tests/fixtures/dataset.json
+++ b/ckanext/dcatapchharvest/tests/fixtures/dataset.json
@@ -135,7 +135,7 @@
         "https://example.com/documentation-resource-2"
       ],
       "rights": "http://dcat-ap.ch/vocabulary/licenses/terms_by",
-      "license": "https://opendata.swiss/en/terms-of-use/#terms_by",
+      "license": "https://opendata.swiss/terms-of-use/#terms_by",
       "format": "HTML"
     },
     {

--- a/ckanext/dcatapchharvest/tests/test_dcatap_ch_parse.py
+++ b/ckanext/dcatapchharvest/tests/test_dcatap_ch_parse.py
@@ -32,8 +32,8 @@ class TestSwissDCATAPProfileParsing(BaseParseTest):
              # Resources
             eq_(len(dataset['resources']), 1)
             resource = dataset['resources'][0]
-            eq_(resource['rights'], u'NonCommercialAllowed-CommercialAllowed-ReferenceRequired')
-            eq_(resource['license'], u'NonCommercialAllowed-CommercialWithPermission-ReferenceRequired')
+            eq_(unicode(resource['rights']), u'https://opendata.swiss/en/terms-of-use/#terms_by')
+            eq_(unicode(resource['license']), u'https://opendata.swiss/en/terms-of-use/#terms_by_ask')
 
     def test_dataset_all_fields(self):
 
@@ -146,8 +146,8 @@ class TestSwissDCATAPProfileParsing(BaseParseTest):
         eq_(resource['format'], u'html')
         eq_(resource['media_type'], u'text/html')
         eq_(resource['identifier'], u'346265-fr@bundesamt-fur-statistik-bfs')
-        eq_(resource['rights'], u'NonCommercialAllowed-CommercialAllowed-ReferenceRequired')
-        eq_(resource['license'], u'Creative Commons Zero 1.0 Universal (CC0 1.0)')
+        eq_(resource['license'], u'https://opendata.swiss/en/terms-of-use/#terms_by')
+        eq_(resource['rights'], u'http://www.opendefinition.org/licenses/cc-zero')
         eq_(resource['language'], [u'fr'])
         eq_(resource['issued'], u'1900-12-31T00:00:00')
         eq_(resource['temporal_resolution'], u'P1D')
@@ -402,7 +402,7 @@ class TestSwissDCATAPProfileParsing(BaseParseTest):
         dataset = [d for d in p.datasets()][0]
         resource = dataset["resources"][0]
 
-        eq_(resource['rights'], u"NonCommercialAllowed-CommercialWithPermission-ReferenceRequired")
+        eq_(unicode(resource['rights']), u"https://opendata.swiss/en/terms-of-use/#terms_by_ask")
 
     def test_eu_themes_mapping(self):
         contents = self._get_file_contents('catalog-themes.xml')

--- a/ckanext/dcatapchharvest/tests/test_dcatap_ch_parse.py
+++ b/ckanext/dcatapchharvest/tests/test_dcatap_ch_parse.py
@@ -32,8 +32,8 @@ class TestSwissDCATAPProfileParsing(BaseParseTest):
              # Resources
             eq_(len(dataset['resources']), 1)
             resource = dataset['resources'][0]
-            eq_(unicode(resource['rights']), u'https://opendata.swiss/en/terms-of-use/#terms_by')
-            eq_(unicode(resource['license']), u'https://opendata.swiss/en/terms-of-use/#terms_by_ask')
+            eq_(unicode(resource['rights']), u'https://opendata.swiss/terms-of-use/#terms_by')
+            eq_(unicode(resource['license']), u'https://opendata.swiss/terms-of-use/#terms_by_ask')
 
     def test_dataset_all_fields(self):
 
@@ -146,7 +146,7 @@ class TestSwissDCATAPProfileParsing(BaseParseTest):
         eq_(resource['format'], u'html')
         eq_(resource['media_type'], u'text/html')
         eq_(resource['identifier'], u'346265-fr@bundesamt-fur-statistik-bfs')
-        eq_(resource['license'], u'https://opendata.swiss/en/terms-of-use/#terms_by')
+        eq_(resource['license'], u'https://opendata.swiss/terms-of-use/#terms_by')
         eq_(resource['rights'], u'http://www.opendefinition.org/licenses/cc-zero')
         eq_(resource['language'], [u'fr'])
         eq_(resource['issued'], u'1900-12-31T00:00:00')
@@ -402,7 +402,7 @@ class TestSwissDCATAPProfileParsing(BaseParseTest):
         dataset = [d for d in p.datasets()][0]
         resource = dataset["resources"][0]
 
-        eq_(unicode(resource['rights']), u"https://opendata.swiss/en/terms-of-use/#terms_by_ask")
+        eq_(unicode(resource['rights']), u"https://opendata.swiss/terms-of-use/#terms_by_ask")
 
     def test_eu_themes_mapping(self):
         contents = self._get_file_contents('catalog-themes.xml')

--- a/ckanext/dcatapchharvest/tests/test_dcatap_ch_serialize.py
+++ b/ckanext/dcatapchharvest/tests/test_dcatap_ch_serialize.py
@@ -113,22 +113,22 @@ class TestDCATAPCHProfileSerializeDataset(BaseSerializeTest):
             if resource_dict.get('rights') == 'Creative Commons Zero 1.0 Universal (CC0 1.0)':
                 assert self._triple(g, distribution, DCT.rights, URIRef("https://creativecommons.org/publicdomain/zero/1.0/"))
 
-            if resource_dict.get('license') == 'NonCommercialAllowed-CommercialAllowed-ReferenceNotRequired':
+            if resource_dict.get('license') == 'https://opendata.swiss/terms-of-use/#terms_open':
                 assert self._triple(g, distribution, DCT.license, URIRef("http://dcat-ap.ch/vocabulary/licenses/terms_open"))
 
             # 28e75e40-e1a1-497b-a1b9-8c1834d60201
-            if resource_dict.get('rights') == "http://dcat-ap.ch/vocabulary/licenses/terms_by":
+            if resource_dict.get('rights') == "https://opendata.swiss/terms-of-use#terms_by":
                 assert self._triple(g, distribution, DCT.rights, URIRef("http://dcat-ap.ch/vocabulary/licenses/terms_by"))
 
-            if resource_dict.get('license') == "NonCommercialAllowed-CommercialAllowed-ReferenceRequired":
+            if resource_dict.get('license') == "https://opendata.swiss/terms-of-use#terms_by":
                 assert self._triple(g, distribution, DCT.license, URIRef("http://dcat-ap.ch/vocabulary/licenses/terms_by"))
 
             # 0cfce6ba-28f4-4229-b733-f6492c650395
-            if resource_dict.get('rights') == "http://dcat-ap.ch/vocabulary/licenses/terms_by_ask":
+            if resource_dict.get('rights') == "https://opendata.swiss/terms-of-use#terms_by_ask":
                 assert self._triple(g, distribution, DCT.rights, URIRef("http://dcat-ap.ch/vocabulary/licenses/terms_by_ask"))
 
-            if resource_dict.get('license') == "https://creativecommons.org/licenses/by/4.0/":
-                assert self._triple(g, distribution, DCT.license, URIRef("https://creativecommons.org/licenses/by/4.0/"))
+            if resource_dict.get('rights') == "	http://www.opendefinition.org/licenses/cc-by/":
+                assert self._triple(g, distribution, DCT.rights, URIRef("https://creativecommons.org/licenses/by/4.0/"))
 
             if resource_dict.get('format') == "CSV":
                 assert self._triple(g, distribution, DCT['format'], URIRef("http://publications.europa.eu/resource/authority/file-type/CSV"))

--- a/ckanext/dcatapchharvest/tests/test_dcatap_ch_serialize.py
+++ b/ckanext/dcatapchharvest/tests/test_dcatap_ch_serialize.py
@@ -110,10 +110,10 @@ class TestDCATAPCHProfileSerializeDataset(BaseSerializeTest):
                 assert self._triple(g, distribution, DCAT.accessService, URIRef(link))
 
             # e2c50e70-67ad-4f86-bb1b-3f93867eadaa
-            if resource_dict.get('rights') == 'Creative Commons Zero 1.0 Universal (CC0 1.0)':
+            if resource_dict.get('rights') == "http://www.opendefinition.org/licenses/cc-zero":
                 assert self._triple(g, distribution, DCT.rights, URIRef("https://creativecommons.org/publicdomain/zero/1.0/"))
 
-            if resource_dict.get('license') == 'https://opendata.swiss/terms-of-use/#terms_open':
+            if resource_dict.get('license') == "https://opendata.swiss/terms-of-use/#terms_open":
                 assert self._triple(g, distribution, DCT.license, URIRef("http://dcat-ap.ch/vocabulary/licenses/terms_open"))
 
             # 28e75e40-e1a1-497b-a1b9-8c1834d60201
@@ -127,7 +127,7 @@ class TestDCATAPCHProfileSerializeDataset(BaseSerializeTest):
             if resource_dict.get('rights') == "https://opendata.swiss/terms-of-use#terms_by_ask":
                 assert self._triple(g, distribution, DCT.rights, URIRef("http://dcat-ap.ch/vocabulary/licenses/terms_by_ask"))
 
-            if resource_dict.get('rights') == "	http://www.opendefinition.org/licenses/cc-by/":
+            if resource_dict.get('rights') == "http://www.opendefinition.org/licenses/cc-by/":
                 assert self._triple(g, distribution, DCT.rights, URIRef("https://creativecommons.org/licenses/by/4.0/"))
 
             if resource_dict.get('format') == "CSV":


### PR DESCRIPTION
1 - parsing of the dataset: 
**License** output of opendata.swiss should only be **our 4 terms** of use with the corresponding URIs https://www.dcat-ap.ch/vocabulary/licenses/20210623.html 

Via ckan dataset API we see licence URIs, example: 
instead of
"license": "NonCommercialAllowed-CommercialAllowed-ReferenceNotRequired",
we show 
 "license": "https://opendata.swiss/terms-of-use#terms_open" 

instead of
  "rights": "Creative Commons Namensnennung - Weitergabe unter gleichen Bedingungen (CC-BY-SA)",
  we show
 "rights": "http://www.opendefinition.org/licenses/cc-by-sa

In case we do not have License we check if rights is there and if it one of 4 terms we take it from rights.

 2- dataset to graph:
 
 we export licences and rights in a way:
 <dct:license rdf:resource="http://dcat-ap.ch/vocabulary/licenses/terms_open"/>
 <dct:rights rdf:resource="https://creativecommons.org/licenses/by-sa/4.0"/>
 
 
3- if rights are not in our vocabulary https://www.dcat-ap.ch/vocabulary/licenses/20210623.html
we do not show it