### PR TITLE
Tests/adapt test for parsing incorrect datetime formats

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,4 +67,4 @@ jobs:
           ckan -c test.ini db init
           ckan -c test.ini db pending-migrations --apply
       - name: Run tests
-        run: pytest --ckan-ini=test.ini --disable-warnings  --cov=ckanext.dcatapchharvest ckanext/dcatapchharvest
+        run: pytest --ckan-ini=test.ini --disable-warnings -v --cov=ckanext.dcatapchharvest ckanext/dcatapchharvest

--- a/ckanext/dcatapchharvest/tests/fixtures/dataset-datetimes-bad.xml
+++ b/ckanext/dcatapchharvest/tests/fixtures/dataset-datetimes-bad.xml
@@ -34,37 +34,61 @@
         <schema:endDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1997</schema:endDate>
       </dct:PeriodOfTime>
     </dct:temporal>
-    <!--  using xsd:date, xsd:gYearMonth or xsd:gYear, but incorrectly specifying date: will be parsed as isodate as
-    far as possible when rdflib creates the graph and will be mapped, but values might not be what the data publisher
-    expected.  -->
+    <!--  using xsd:date, xsd:gYearMonth or xsd:gYear, but incorrectly specifying date: will not be mapped  -->
     <dct:temporal>
       <dct:PeriodOfTime>
-        <schema:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">1998-04</schema:startDate>
-        <schema:endDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">1999</schema:endDate>
+        <schema:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">1998</schema:startDate>
+        <schema:endDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">1999-4-4</schema:endDate>
       </dct:PeriodOfTime>
     </dct:temporal>
     <dct:temporal>
       <dct:PeriodOfTime>
-        <schema:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2000-11-21T01:02:03</schema:startDate>
-        <schema:endDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2001T01:02:03</schema:endDate>
+        <dcat:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gYearMonth">2000-4</dcat:startDate>
+        <dcat:endDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gYearMonth">2001-6-06</dcat:endDate>
       </dct:PeriodOfTime>
     </dct:temporal>
     <dct:temporal>
       <dct:PeriodOfTime>
-        <dcat:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gYearMonth">2002-01-01T00:00:00</dcat:startDate>
+        <dcat:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gYearMonth">2002-01T00:00:00</dcat:startDate>
         <dcat:endDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gYearMonth">2003</dcat:endDate>
       </dct:PeriodOfTime>
     </dct:temporal>
     <dct:temporal>
       <dct:PeriodOfTime>
-        <dcat:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gYear">2004-01-02</dcat:startDate>
-        <dcat:endDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gYear">2005-12</dcat:endDate>
+        <dcat:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gYearMonth">2004-4-1</dcat:startDate>
+        <dcat:endDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gYearMonth">2005-6-6</dcat:endDate>
+      </dct:PeriodOfTime>
+    </dct:temporal>
+    <!--  using xsd:gYear, but incorrectly specifying date: will be parsed as isodate as far as possible when rdflib
+    creates the graph and will be mapped, but values might not be what the data publisher expected.  -->
+    <dct:temporal>
+      <dct:PeriodOfTime>
+        <schema:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2006-11-21T01:02:03</schema:startDate>
+        <schema:endDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2007-11T01:02:03</schema:endDate>
       </dct:PeriodOfTime>
     </dct:temporal>
     <dct:temporal>
       <dct:PeriodOfTime>
-        <dcat:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gYearMonth">2006-4</dcat:startDate>
-        <dcat:endDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gYearMonth">2007-6-6</dcat:endDate>
+        <dcat:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gYear">2008-04-02</dcat:startDate>
+        <dcat:endDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gYear">2009-06</dcat:endDate>
+      </dct:PeriodOfTime>
+    </dct:temporal>
+    <dct:temporal>
+      <dct:PeriodOfTime>
+        <schema:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2010-04</schema:startDate>
+        <schema:endDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2011-05</schema:endDate>
+      </dct:PeriodOfTime>
+    </dct:temporal>
+    <dct:temporal>
+      <dct:PeriodOfTime>
+        <schema:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2012-11-21T01:02:03</schema:startDate>
+        <schema:endDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2013-11-21T01:02:03</schema:endDate>
+      </dct:PeriodOfTime>
+    </dct:temporal>
+    <dct:temporal>
+      <dct:PeriodOfTime>
+        <dcat:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gYearMonth">2014-04-06T00:00:00</dcat:startDate>
+        <dcat:endDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gYearMonth">2015-01-02</dcat:endDate>
       </dct:PeriodOfTime>
     </dct:temporal>
     <!--  using XSD datatypes, with an invalid date or datetime: should not be mapped  -->

--- a/ckanext/dcatapchharvest/tests/test_dcatap_ch_parse.py
+++ b/ckanext/dcatapchharvest/tests/test_dcatap_ch_parse.py
@@ -398,26 +398,26 @@ class TestSwissDCATAPProfileParsing(BaseParseTest):
         dataset = [d for d in p.datasets()][0]
         assert len(dataset["temporals"]) == 5
 
-        assert sorted(dataset["temporals"]) == [
+        assert sorted(dataset["temporals"], key=lambda x: x["start_date"]) == [
             {
-                "start_date": "1998-04-01T00:00:00",
-                "end_date": "1999-01-01T23:59:59.999999",
+                "start_date": "2006-11-21T00:00:00",
+                "end_date": "2007-11-01T23:59:59.999999",
             },
             {
-                "start_date": "2000-11-21T00:00:00",
-                "end_date": "2001-01-01T23:59:59.999999",
+                "start_date": "2008-01-01T00:00:00",
+                "end_date": "2009-12-31T23:59:59.999999",
             },
             {
-                "start_date": "2002-01-01T00:00:00",
-                "end_date": "2003-01-31T23:59:59.999999",
+                "start_date": "2010-04-01T00:00:00",
+                "end_date": "2011-05-01T23:59:59.999999",
             },
             {
-                "start_date": "2004-01-01T00:00:00",
-                "end_date": "2005-12-31T23:59:59.999999",
+                "start_date": "2012-11-21T00:00:00",
+                "end_date": "2013-11-21T23:59:59.999999",
             },
             {
-                "start_date": "2006-01-01T00:00:00",
-                "end_date": "2007-01-31T23:59:59.999999",
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": "2015-01-31T23:59:59.999999",
             },
         ]
 


### PR DESCRIPTION
Some of the dates/datetimes that were specified incorrectly or with the wrong datatype could no longer be parsed from the graph, because rdflib already threw an error due to the mismatched datatype. In this case, the values never get to our _clean_datetime method to be parsed by isodate.

I have tried to update the fixture and the test to reflect the full range of what badly-specified dates/datetimes can be massaged into some kind of shape by our code, and which can't. Of course, the solution is that everyone should just do the right thing all the time.