### PR TITLE
Move config declaration to I14Y Class

### DIFF
--- a/ckanext/dcatapchharvest/harvesters.py
+++ b/ckanext/dcatapchharvest/harvesters.py
@@ -203,6 +203,7 @@ def _derive_flat_title(title_dict):
     )
 
 
+@tk.blanket.config_declarations
 class SwissDCATI14YRDFHarvester(SwissDCATRDFHarvester):
 
     def info(self):


### PR DESCRIPTION
After changing the position of the plugins, we also need to move config_declarations decorator before I14Y class